### PR TITLE
UNICODE Work for PDCurses (from my old repo)

### DIFF
--- a/curses.h
+++ b/curses.h
@@ -1745,6 +1745,10 @@ PDCEX int     PDC_set_blink(bool);
 PDCEX int     PDC_set_line_color(short);
 PDCEX void    PDC_set_title(const char *);
 
+#ifdef PDC_WIDE
+PDCEX void	  PDC_set_titleW(const wchar_t*);
+#endif
+
 PDCEX int     PDC_clearclipboard(void);
 PDCEX int     PDC_freeclipboard(char *);
 PDCEX int     PDC_getclipboard(char **, long *);

--- a/dos/pdcsetsc.c
+++ b/dos/pdcsetsc.c
@@ -74,6 +74,13 @@ void PDC_set_title(const char *title)
     PDC_LOG(("PDC_set_title() - called: <%s>\n", title));
 }
 
+#ifdef PDC_WIDE
+void PDC_set_titleW(const wchar_t *title)
+{
+    PDC_LOG_W(("PDC_set_titleW() - called: <%s>\n", title));
+}
+#endif
+
 int PDC_set_blink(bool blinkon)
 {
     PDCREGS regs;

--- a/os2/pdcsetsc.c
+++ b/os2/pdcsetsc.c
@@ -87,6 +87,13 @@ void PDC_set_title(const char *title)
     PDC_LOG(("PDC_set_title() - called:<%s>\n", title));
 }
 
+#ifdef PDC_WIDE
+void PDC_set_titleW(const wchar_t *title)
+{
+    PDC_LOG_W(("PDC_set_titleW() - called:<%s>\n", title));
+}
+#endif
+
 int PDC_set_blink(bool blinkon)
 {
 #ifndef EMXVIDEO

--- a/sdl2/pdcsetsc.c
+++ b/sdl2/pdcsetsc.c
@@ -55,6 +55,15 @@ void PDC_set_title(const char *title)
     SDL_SetWindowTitle(pdc_window, title);
 }
 
+#ifdef PDC_WIDE
+void PDC_set_titleW(const char *title)
+{
+    PDC_LOG_W(("PDC_set_titleW() - called:<%s>\n", title));
+
+//    SDL_SetWindowTitle(pdc_window, title);
+}
+#endif
+
 /* See comments in win32a/pdcsetsc.c or x11/pdcsetsc.c.  This does
 essentially the same thing. */
 

--- a/win32/pdcsetsc.c
+++ b/win32/pdcsetsc.c
@@ -67,8 +67,9 @@ int PDC_curs_set(int visibility)
     return ret_vis;
 }
 
-void PDC_set_title(const char *title)
+/*void PDC_set_title(const char *title)
 {
+    extern HWND PDC_hWnd;
 #ifdef PDC_WIDE
     wchar_t wtitle[512];
 #endif
@@ -76,11 +77,28 @@ void PDC_set_title(const char *title)
 
 #ifdef PDC_WIDE
     PDC_mbstowcs(wtitle, title, 511);
-    SetConsoleTitleW(wtitle);
+    SetWindowTextW( PDC_hWnd, wtitle);
 #else
-    SetConsoleTitleA(title);
+    SetWindowTextA( PDC_hWnd, title);
 #endif
+}*/
+
+void PDC_set_title(const char *title)
+{
+	extern HWND PDC_hWnd;
+	PDC_LOG(("PDC_set_title() - called:<%s>\n", title));
+	SetWindowTextA( PDC_hWnd, title);
 }
+
+#ifdef PDC_WIDE
+void PDC_set_titleW(const wchar_t *title)
+{
+    extern HWND PDC_hWnd;
+    PDC_LOG_W(("PDC_set_titleW() - called:<%s>\n", title));
+
+    SetWindowTextW( PDC_hWnd, title);
+}
+#endif
 
 int PDC_set_blink(bool blinkon)
 {

--- a/win32/pdcwin.h
+++ b/win32/pdcwin.h
@@ -1,7 +1,9 @@
 /* Public Domain Curses */
 
 #ifdef PDC_WIDE
+#ifndef UNICODE
 # define UNICODE
+#endif
 #endif
 
 #include <windows.h>

--- a/win32a/pdcsetsc.c
+++ b/win32a/pdcsetsc.c
@@ -46,7 +46,7 @@ int PDC_curs_set(int visibility)
     return ret_vis;
 }
 
-void PDC_set_title(const char *title)
+/*void PDC_set_title(const char *title)
 {
     extern HWND PDC_hWnd;
 #ifdef PDC_WIDE
@@ -60,7 +60,24 @@ void PDC_set_title(const char *title)
 #else
     SetWindowTextA( PDC_hWnd, title);
 #endif
+}*/
+
+void PDC_set_title(const char *title)
+{
+	extern HWND PDC_hWnd;
+	PDC_LOG(("PDC_set_title() - called:<%s>\n", title));
+	SetWindowTextA( PDC_hWnd, title);
 }
+
+#ifdef PDC_WIDE
+void PDC_set_titleW(const wchar_t *title)
+{
+    extern HWND PDC_hWnd;
+    PDC_LOG_W(("PDC_set_titleW() - called:<%s>\n", title));
+
+    SetWindowTextW( PDC_hWnd, title);
+}
+#endif
 
         /* If PDC_really_blinking is TRUE,  then text with the A_BLINK   */
         /* attribute will actually blink.  Otherwise,  such text will    */

--- a/win32a/pdcwin.h
+++ b/win32a/pdcwin.h
@@ -3,8 +3,12 @@
 /* $Id: pdcwin.h,v 1.6 2008/07/13 06:36:32 wmcbrine Exp $ */
 
 #ifdef PDC_WIDE
+#ifndef UNICODE
 # define UNICODE
+#endif
+#ifndef _UNICODE
 # define _UNICODE
+#endif
 #endif
 
 #include <windows.h>

--- a/x11/pdcsetsc.c
+++ b/x11/pdcsetsc.c
@@ -67,6 +67,26 @@ void PDC_set_title(const char *title)
     XCursesExitCursesProcess(1, "exiting from PDC_set_title");
 }
 
+#ifdef PDC_WIDE
+void PDC_set_titleW(const wchar_t *title)
+{
+//    int len;
+
+    PDC_LOG_W(("PDC_set_titleW() - called:<%s>\n", title));
+
+ //   len = wcslen(title) + 1;        /* write nul character */
+
+  /*  XCursesInstruct(CURSES_TITLE);
+
+    if (XC_write_display_socket_int(len) >= 0)
+        if (XC_write_socket(xc_display_sock, title, len) >= 0)
+            return;
+
+    XCursesExitCursesProcess(1, "exiting from PDC_set_title");*/
+}
+#endif
+
+
         /* If PDC_really_blinking is TRUE,  then text with the A_BLINK   */
         /* attribute will actually blink.  Otherwise,  such text will    */
         /* be shown with higher color intensity (the R, G, and B values  */


### PR DESCRIPTION
Commit 1: When you compile using Visual Studio and Unicode project enabled and PDC_WIDE defined, it will create some warning because MSVC alreadly define UNICODE and _UNICODE macro
This should fix this warning

Commit 2: I had the necessity to set the console title to UNICODE because i'm coding a windows project using PDC in UNICODE format. Unfortunally PDC dosen't have any wchar_t recognization. This commit works only for Windows, other groups dosen't have wchar_t support for passing that argument. It also provide a "clear" implementation of current PDC_set_title with char