### PR TITLE
wincon: write characters one by one to display full-width characters correctly

### DIFF
--- a/wincon/Makefile.mng
+++ b/wincon/Makefile.mng
@@ -86,6 +86,10 @@ ifeq ($(WIDE),Y)
 	CFLAGS += -DPDC_WIDE
 endif
 
+ifeq ($(NEW_WINCON_WORKAROUND),Y)
+	CFLAGS += -DPDC_NEW_WINCON_WORKAROUND
+endif
+
 ifeq ($(UTF8),Y)
 	CFLAGS += -DPDC_FORCE_UTF8
 endif

--- a/wincon/Makefile.mng
+++ b/wincon/Makefile.mng
@@ -86,10 +86,6 @@ ifeq ($(WIDE),Y)
 	CFLAGS += -DPDC_WIDE
 endif
 
-ifeq ($(NEW_WINCON_WORKAROUND),Y)
-	CFLAGS += -DPDC_NEW_WINCON_WORKAROUND
-endif
-
 ifeq ($(UTF8),Y)
 	CFLAGS += -DPDC_FORCE_UTF8
 endif

--- a/wincon/pdcdisp.c
+++ b/wincon/pdcdisp.c
@@ -108,11 +108,34 @@ void PDC_transform_line(int lineno, int x, int len, const chtype *srcp)
 #endif
             ci[dst].Char.UnicodeChar = (WCHAR)char_out;
 
+#ifdef PDC_NEW_WINCON_WORKAROUND
+            sr.Left = x + src;
+            if( src < len - 1 &&
+               (srcp[src + 1] & A_CHARTEXT) == DUMMY_CHAR_NEXT_TO_FULLWIDTH)
+            {
+                 /* necessary to erase garbage */
+                ci[dst + 1].Char.UnicodeChar = (WCHAR)' ';
+                ci[dst + 1].Attributes = ci[dst].Attributes;
+                bufSize.X = 2;
+                bufSize.Y = 1;
+                sr.Right = sr.Left + 2;
+            }
+            else
+            {
+                bufSize.X = 1;
+                bufSize.Y = 1;
+                sr.Right = sr.Left + 1;
+            }
+            WriteConsoleOutput(pdc_con_out, ci, bufSize, bufPos, &sr);
+#else
             dst++;
+#endif
         }
 
+#ifndef PDC_NEW_WINCON_WORKAROUND
     bufSize.X = dst;
     bufSize.Y = 1;
 
     WriteConsoleOutput(pdc_con_out, ci, bufSize, bufPos, &sr);
+#endif
 }

--- a/wincon/pdcdisp.c
+++ b/wincon/pdcdisp.c
@@ -50,6 +50,8 @@ void PDC_gotoyx(int row, int col)
    int PDC_expand_combined_characters( const cchar_t c, cchar_t *added);  /* addch.c */
 #endif
 
+#define PDC_NEW_WINCON_WORKAROUND 1
+
 void PDC_transform_line(int lineno, int x, int len, const chtype *srcp)
 {
     CHAR_INFO ci[512];


### PR DESCRIPTION
Otherwise, full-width characters overlap on a [new Windows console](https://docs.microsoft.com/en-us/previous-versions/orphan-topics/ws.11/mt427362(v=ws.11)).

![win_fullwidth_ng](https://user-images.githubusercontent.com/34552/54249667-62f90f80-4584-11e9-9a0b-038f51f45cba.png)
