### PR TITLE
wincon & wingui: Play beeps synchronously so multiple beeps work

### DIFF
--- a/wincon/Makefile.dmc
+++ b/wincon/Makefile.dmc
@@ -58,6 +58,8 @@ pdcsetsc.obj pdcutil.obj
 DEMOOBJS = testcurs.obj ozdemo.obj newtest.obj xmas.obj tuidemo.obj tui.obj \
 firework.obj ptest.obj rain.obj worm.obj
 
+LIBS = winmm.lib
+
 $(LIBOBJS) $(PDCOBJS) : $(PDCURSES_HEADERS)
 $(PDCOBJS) : $(PDCURSES_WIN_H)
 panel.obj ptest.obj: $(PANEL_HEADER)

--- a/wincon/Makefile.mng
+++ b/wincon/Makefile.mng
@@ -100,7 +100,7 @@ ifeq ($(DLL),Y)
 	LIBFLAGS = -Wl,--out-implib,pdcurses.a -shared -o
 	LIBCURSES = pdcurses.dll
 	LIBDEPS = $(LIBOBJS) $(PDCOBJS)
-	LIBSADDED =
+	LIBSADDED = -lwinmm
 	EXELIBS =
 	CLEAN = $(LIBCURSES) *.a
 else
@@ -113,7 +113,7 @@ endif
 	LIBCURSES = pdcurses.a
 	LIBDEPS = $(LIBOBJS) $(PDCOBJS)
 	LIBSADDED =
-	EXELIBS =
+	EXELIBS = -lwinmm
 	CLEAN = *.a
 endif
 
@@ -154,7 +154,7 @@ version.exe worm.exe xmas.exe: %.exe: $(demodir)/%.c
 	$(CC) $(CFLAGS) -o$@ $< $(LIBCURSES) $(EXELIBS)
 
 tuidemo.exe: tuidemo.o tui.o
-	$(LINK) $(LDFLAGS) -o$@ tuidemo.o tui.o $(LIBCURSES)
+	$(LINK) $(LDFLAGS) -o$@ tuidemo.o tui.o $(LIBCURSES) $(EXELIBS)
 
 tui.o: $(demodir)/tui.c $(demodir)/tui.h $(PDCURSES_CURSES_H)
 	$(CC) -c $(CFLAGS) -I$(demodir) -o$@ $<

--- a/wincon/Makefile.vc
+++ b/wincon/Makefile.vc
@@ -47,9 +47,9 @@ CC		= cl.exe -nologo
 LINK		= link.exe -nologo
 SHL_LD		= $(LINK) $(LDFLAGS) -dll -machine:$(PLATFORM) -out:pdcurses.dll
 
-CCLIBS		= user32.lib advapi32.lib
+CCLIBS		= user32.lib advapi32.lib winmm.lib
 # may need to add msvcrt for older compilers
-#CCLIBS		= msvcrt.lib user32.lib advapi32.lib
+#CCLIBS		= msvcrt.lib user32.lib advapi32.lib winmm.lib
 
 LIBEXE		= lib -nologo
 

--- a/wincon/pdcutil.c
+++ b/wincon/pdcutil.c
@@ -1,13 +1,16 @@
 /* PDCurses */
 
 #include "pdcwin.h"
+#ifdef WIN32_LEAN_AND_MEAN
+#include <mmsystem.h>
+#endif
 
 void PDC_beep(void)
 {
     PDC_LOG(("PDC_beep() - called\n"));
 
-/*  MessageBeep(MB_OK); */
-    MessageBeep(0XFFFFFFFF);
+    if (!PlaySound((LPCTSTR) SND_ALIAS_SYSTEMDEFAULT, NULL, SND_ALIAS_ID))
+        Beep(800, 200);
 }
 
 void PDC_napms(int ms)

--- a/wingui/Makefile.dmc
+++ b/wingui/Makefile.dmc
@@ -59,7 +59,7 @@ pdcsetsc.obj pdcutil.obj
 DEMOOBJS = testcurs.obj ozdemo.obj newtest.obj xmas.obj tuidemo.obj tui.obj \
 firework.obj ptest.obj rain.obj worm.obj
 
-LIBS = advapi32.lib gdi32.lib user32.lib shell32.lib comdlg32.lib
+LIBS = advapi32.lib gdi32.lib user32.lib shell32.lib comdlg32.lib winmm.lib
 
 $(LIBOBJS) $(PDCOBJS) : $(PDCURSES_HEADERS)
 $(PDCOBJS) : $(PDCURSES_WIN_H)

--- a/wingui/Makefile.mng
+++ b/wingui/Makefile.mng
@@ -98,7 +98,7 @@ ifeq ($(DLL),Y)
 	LIBFLAGS = -Wl,--out-implib,pdcurses.a -static-libgcc -shared -o
 	LIBCURSES = pdcurses.dll
 	LIBDEPS = $(LIBOBJS) $(PDCOBJS)
-	LIBSADDED = -lgdi32 -lcomdlg32
+	LIBSADDED = -lgdi32 -lcomdlg32 -lwinmm
 	EXELIBS =
 	CLEAN = $(LIBCURSES) *.a
 else
@@ -111,7 +111,7 @@ endif
 	LIBCURSES = pdcurses.a
 	LIBDEPS = $(LIBOBJS) $(PDCOBJS)
 	LIBSADDED =
-	EXELIBS = -lgdi32 -lcomdlg32
+	EXELIBS = -lgdi32 -lcomdlg32 -lwinmm
 	CLEAN = *.a
 endif
 

--- a/wingui/Makefile.vc
+++ b/wingui/Makefile.vc
@@ -62,9 +62,11 @@ CHTYPE_FLAGS= -DCHTYPE_32
 
 SHL_LD = link $(LDFLAGS) /NOLOGO /DLL /MACHINE:$(PLATFORM) /OUT:pdcurses.dll
 
-CCLIBS      = user32.lib gdi32.lib advapi32.lib shell32.lib comdlg32.lib
+CCLIBS      = user32.lib gdi32.lib advapi32.lib shell32.lib comdlg32.lib \
+winmm.lib
 # may need to add msvcrt.lib for VC 2.x, VC 5.0 doesn't want it
-#CCLIBS      = msvcrt.lib user32.lib gdi32.lib advapi32.lib comdlg32.lib
+#CCLIBS      = msvcrt.lib user32.lib gdi32.lib advapi32.lib shell32.lib \
+#comdlg32.lib winmm.lib
 
 LIBEXE      = lib -nologo
 

--- a/wingui/pdcutil.c
+++ b/wingui/pdcutil.c
@@ -1,19 +1,25 @@
 /* Public Domain Curses */
 
 #include "pdcwin.h"
+#ifdef WIN32_LEAN_AND_MEAN
+#include <mmsystem.h>
+#endif
+
+extern CRITICAL_SECTION PDC_cs;
 
 void PDC_beep(void)
 {
     PDC_LOG(("PDC_beep() - called\n"));
 
-/*  MessageBeep(MB_OK); */
-    MessageBeep(0XFFFFFFFF);
+    LeaveCriticalSection(&PDC_cs);
+    if (!PlaySound((LPCTSTR) SND_ALIAS_SYSTEMDEFAULT, NULL, SND_ALIAS_ID))
+        Beep(800, 200);
+    EnterCriticalSection(&PDC_cs);
 }
 
 void PDC_napms(int ms)     /* 'ms' = milli,  _not_ microseconds! */
 {
     /* RR: keep GUI window responsive while PDCurses sleeps */
-    extern CRITICAL_SECTION PDC_cs;
 
     PDC_LOG(("PDC_napms() - called: ms=%d\n", ms));
 


### PR DESCRIPTION
While trying out a WinGUI build of the `tuidemo` program on Windows Vista, I observed that the "TwoBeeps" function was only producing one beep. This is because WinGUI's (and WinCon's) implementation of `PDC_beep()` calls `MessageBeep()` to play the Windows default beep sound effect (or a standard beep on the PC speaker as a fallback). As documented, this plays the sound asynchronously, so multiple beeps in a row (as in `tuidemo`) will cancel out each other instead of producing the intended results. (Interestingly, on my Windows NT 4.0 system it plays the sounds synchronously, contrary to the 1997 MSDN documentation for `MessageBeep()`; this could be hardware dependent).

This fix uses `PlaySound()` instead to play the Windows default beep. If it fails, it will fall back on `Beep()` to play a standard PC speaker beep.

Some notes:

- The only caveat to using `PlaySound()` is that it is implemented in winmm.dll; as such, pdcurses.dll and any programs that link statically with PDCurses must be linked with the corresponding library, which isn't necessarily among the Windows libraries linked by default. I've updated the Digital Mars, MinGW/GCC, and Visual C++ makefiles to add it to the list of libraries; the Borland and Watcom makefiles do not contain a field listing Windows libraries to link with. I have only personally tested the MinGW makefile thus far.

- The 800 Hz and 200 ms values passed to `Beep()` produce a beep that, as far as I can tell (from experimentation and searching online), exactly matches the standard beep produced on NT 4.0 and Vista when one `echo`s the ASCII BEL character (Ctrl+G) in a cmd.exe prompt. If simply producing a PC speaker beep (more "natural" for a character mode application) was desired, we could just use the `Beep()` call in all cases (and not have to link with winmm.dll), but this function has sketchy compatibility with some Windows versions: it does not consistently actually produce a beep on my 32-bit Vista system, and from what I gather it may not work at all on 64-bit XP or Vista. (Windows 7 and later, or at least the 64-bit versions thereof, reimplemented it to play the beep using the sound card instead of the PC speaker, which isn't necessarily present anymore on modern motherboards).

- Because WinGUI now manages the window in a separate thread, we can do this while keeping the window responsive by releasing the critical section object while the sound is playing.

- The existing implementation with `MessageBeep()` is identical to the implementation in upstream PDCurses' WinCon port, so I intend to submit this fix there as well provided everything looks good here.