### PR TITLE
SDL-ports: Option to change font render from blended to shaded or solid

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -67,6 +67,9 @@ Minor new features
 -  'test_pan' allows one to move panels around the screen and adjust
    the panel depth.
 
+-  Added ability to change SDL1/SDL2 font rendering mode by setting
+   pdc_sdl_render_mode 
+
 Bug fixes and such
 ------------------
 

--- a/sdl1/README.md
+++ b/sdl1/README.md
@@ -119,7 +119,7 @@ external variables and functions specific to the SDL ports; you could
 include pdcsdl.h, or just add the declarations you need in your code:
 
     PDCEX SDL_Surface *pdc_screen, *pdc_font, *pdc_icon, *pdc_back;
-    PDCEX int pdc_sheight, pdc_swidth, pdc_yoffset, pdc_xoffset;
+    PDCEX int pdc_sheight, pdc_swidth, pdc_yoffset, pdc_xoffset, pdc_sdl_render_mode;
 
     PDCEX void PDC_update_rects(void);
     PDCEX void PDC_retile(void);
@@ -141,6 +141,19 @@ pdc_font (in 8-bit mode), pdc_icon, and pdc_back are the SDL_surfaces
 for the font, icon, and background, respectively. You can set any or all
 of them before initscr(), and thus override any of the other ways to set
 them. But note that pdc_icon will be ignored if pdc_screen is preset.
+
+pdc_sdl_render_mode (in 16-bit mode) can be set to `PDC_SDL_RENDER_SOLID`, 
+`PDC_SDL_RENDER_SHADED` or `PDC_SDL_RENDER_BLENDED`. This determines which SDL TTF
+render mode will be used for rendering text: `TTF_RenderUNICODE_Solid()`, 
+`TTF_RenderUNICODE_Shaded()` or `TTF_RenderUNICODE_Blended()` respectively. 
+This will default to `PDC_SDL_RENDER_BLENDED`. If you wish to use this feature 
+without including `pdcsdl.h`, you must define the following constants:
+
+```
+#define PDC_SDL_RENDER_SOLID 1
+#define PDC_SDL_RENDER_SHADED 2
+#define PDC_SDL_RENDER_BLENDED 3
+```
 
 pdc_sheight and pdc_swidth are the dimensions of the area of pdc_screen
 to be used by PDCurses. You can preset them before initscr(); if either

--- a/sdl1/pdcdisp.c
+++ b/sdl1/pdcdisp.c
@@ -269,8 +269,21 @@ void PDC_gotoyx(int row, int col)
 
         chstr[0] = ch & A_CHARTEXT;
 
-        pdc_font = TTF_RenderUNICODE_Blended(pdc_ttffont, chstr,
-                                             pdc_color[foregr]);
+        switch (pdc_sdl_render_mode)
+        {
+        case PDC_SDL_RENDER_SOLID:
+            pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr,
+                                               pdc_color[foregr]);
+            break;
+        case PDC_SDL_RENDER_SHADED:
+            pdc_font = TTF_RenderUNICODE_Shaded(pdc_ttffont, chstr,
+                                                pdc_color[foregr], pdc_color[backgr]);
+            break;
+        default:
+            pdc_font = TTF_RenderUNICODE_Blended(pdc_ttffont, chstr,
+                                                 pdc_color[foregr]);
+        }
+
         if (pdc_font)
         {
             int center = pdc_fwidth > pdc_font->w ?
@@ -392,8 +405,20 @@ void _new_packet(attr_t attr, int lineno, int x, int len, const chtype *srcp)
                 if (pdc_font)
                     SDL_FreeSurface(pdc_font);
 
-                pdc_font = TTF_RenderUNICODE_Blended(pdc_ttffont, chstr,
-                                                     pdc_color[foregr]);
+                switch (pdc_sdl_render_mode)
+                {
+                case PDC_SDL_RENDER_SOLID:
+                    pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr,
+                                                       pdc_color[foregr]);
+                    break;
+                case PDC_SDL_RENDER_SHADED:
+                    pdc_font = TTF_RenderUNICODE_Shaded(pdc_ttffont, chstr,
+                                                        pdc_color[foregr], pdc_color[backgr]);
+                    break;
+                default:
+                    pdc_font = TTF_RenderUNICODE_Blended(pdc_ttffont, chstr,
+                                                         pdc_color[foregr]);
+                }
             }
 
             if (pdc_font)

--- a/sdl1/pdcscrn.c
+++ b/sdl1/pdcscrn.c
@@ -14,6 +14,7 @@
 # endif
 TTF_Font *pdc_ttffont = NULL;
 int pdc_font_size = 17;
+int pdc_sdl_render_mode = PDC_SDL_RENDER_BLENDED;
 #endif
 
 SDL_Surface *pdc_screen = NULL, *pdc_font = NULL, *pdc_icon = NULL,

--- a/sdl1/pdcsdl.h
+++ b/sdl1/pdcsdl.h
@@ -14,6 +14,11 @@
 #ifdef PDC_WIDE
 PDCEX  TTF_Font *pdc_ttffont;
 PDCEX  int pdc_font_size;
+#define PDC_SDL_RENDER_SOLID 1
+#define PDC_SDL_RENDER_SHADED 2
+#define PDC_SDL_RENDER_BLENDED 3
+
+PDCEX int pdc_sdl_render_mode;
 #endif
 PDCEX  SDL_Surface *pdc_screen, *pdc_font, *pdc_icon, *pdc_back;
 PDCEX  int pdc_sheight, pdc_swidth, pdc_yoffset, pdc_xoffset;

--- a/sdl2/README.md
+++ b/sdl2/README.md
@@ -132,7 +132,7 @@ include pdcsdl.h, or just add the declarations you need in your code:
 
     PDCEX SDL_Window *pdc_window;
     PDCEX SDL_Surface *pdc_screen, *pdc_font, *pdc_icon, *pdc_back;
-    PDCEX int pdc_sheight, pdc_swidth, pdc_yoffset, pdc_xoffset, pdc_font_render_fast;
+    PDCEX int pdc_sheight, pdc_swidth, pdc_yoffset, pdc_xoffset, pdc_font_render_mode;
 
     PDCEX void PDC_update_rects(void);
     PDCEX void PDC_retile(void);
@@ -156,9 +156,18 @@ for the font, icon, and background, respectively. You can set any or all
 of them before initscr(), and thus override any of the other ways to set
 them. But note that pdc_icon will be ignored if pdc_screen is preset.
 
-pdc_font_render_fast (in 16-bit mode) will render text using 
-TTF_RenderUNICODE_Solid instead of TTF_RenderUNICODE_Blended, which is the 
-default.
+pdc_ttf_render_mode (in 16-bit mode) can be set to `PDC_TTF_RENDER_SOLID`, 
+`PDC_TTF_RENDER_SHADED` or `PDC_TTF_RENDER_BLENDED`. This determines which SDL TTF
+render mode will be used for rendering text: `TTF_RenderUNICODE_Solid()`, 
+`TTF_RenderUNICODE_Shaded()` or `TTF_RenderUNICODE_Blended()` respectively. 
+This will default to `PDC_TTF_RENDER_BLENDED`. If you wish to use this feature 
+without including `pdcsdl.h`, you must define the following constants:
+
+```
+#define PDC_TTF_RENDER_SOLID 0x01
+#define PDC_TTF_RENDER_SHADED 0x02
+#define PDC_TTF_RENDER_BLENDED 0x03
+```
 
 pdc_sheight and pdc_swidth are the dimensions of the area of pdc_screen
 to be used by PDCurses. You can preset them before initscr(); if either

--- a/sdl2/README.md
+++ b/sdl2/README.md
@@ -132,7 +132,7 @@ include pdcsdl.h, or just add the declarations you need in your code:
 
     PDCEX SDL_Window *pdc_window;
     PDCEX SDL_Surface *pdc_screen, *pdc_font, *pdc_icon, *pdc_back;
-    PDCEX int pdc_sheight, pdc_swidth, pdc_yoffset, pdc_xoffset, pdc_font_render_mode;
+    PDCEX int pdc_sheight, pdc_swidth, pdc_yoffset, pdc_xoffset, pdc_sdl_render_mode;
 
     PDCEX void PDC_update_rects(void);
     PDCEX void PDC_retile(void);

--- a/sdl2/README.md
+++ b/sdl2/README.md
@@ -156,17 +156,17 @@ for the font, icon, and background, respectively. You can set any or all
 of them before initscr(), and thus override any of the other ways to set
 them. But note that pdc_icon will be ignored if pdc_screen is preset.
 
-pdc_ttf_render_mode (in 16-bit mode) can be set to `PDC_TTF_RENDER_SOLID`, 
-`PDC_TTF_RENDER_SHADED` or `PDC_TTF_RENDER_BLENDED`. This determines which SDL TTF
+pdc_sdl_render_mode (in 16-bit mode) can be set to `PDC_SDL_RENDER_SOLID`, 
+`PDC_SDL_RENDER_SHADED` or `PDC_SDL_RENDER_BLENDED`. This determines which SDL TTF
 render mode will be used for rendering text: `TTF_RenderUNICODE_Solid()`, 
 `TTF_RenderUNICODE_Shaded()` or `TTF_RenderUNICODE_Blended()` respectively. 
-This will default to `PDC_TTF_RENDER_BLENDED`. If you wish to use this feature 
+This will default to `PDC_SDL_RENDER_BLENDED`. If you wish to use this feature 
 without including `pdcsdl.h`, you must define the following constants:
 
 ```
-#define PDC_TTF_RENDER_SOLID 0x01
-#define PDC_TTF_RENDER_SHADED 0x02
-#define PDC_TTF_RENDER_BLENDED 0x03
+#define PDC_SDL_RENDER_SOLID 1
+#define PDC_SDL_RENDER_SHADED 2
+#define PDC_SDL_RENDER_BLENDED 3
 ```
 
 pdc_sheight and pdc_swidth are the dimensions of the area of pdc_screen

--- a/sdl2/README.md
+++ b/sdl2/README.md
@@ -132,7 +132,7 @@ include pdcsdl.h, or just add the declarations you need in your code:
 
     PDCEX SDL_Window *pdc_window;
     PDCEX SDL_Surface *pdc_screen, *pdc_font, *pdc_icon, *pdc_back;
-    PDCEX int pdc_sheight, pdc_swidth, pdc_yoffset, pdc_xoffset;
+    PDCEX int pdc_sheight, pdc_swidth, pdc_yoffset, pdc_xoffset, pdc_font_render_fast;
 
     PDCEX void PDC_update_rects(void);
     PDCEX void PDC_retile(void);
@@ -155,6 +155,10 @@ pdc_font (in 8-bit mode), pdc_icon, and pdc_back are the SDL_surfaces
 for the font, icon, and background, respectively. You can set any or all
 of them before initscr(), and thus override any of the other ways to set
 them. But note that pdc_icon will be ignored if pdc_screen is preset.
+
+pdc_font_render_fast (in 16-bit mode) will render text using 
+TTF_RenderUNICODE_Solid instead of TTF_RenderUNICODE_Blended, which is the 
+default.
 
 pdc_sheight and pdc_swidth are the dimensions of the area of pdc_screen
 to be used by PDCurses. You can preset them before initscr(); if either

--- a/sdl2/pdcdisp.c
+++ b/sdl2/pdcdisp.c
@@ -531,7 +531,7 @@ static Uint32 _blink_timer(Uint32 interval, void *param)
 
     event.type = SDL_USEREVENT;
     SDL_PushEvent(&event);
-    return (interval);
+    return(interval);
 }
 
 void PDC_blink_text(void)

--- a/sdl2/pdcdisp.c
+++ b/sdl2/pdcdisp.c
@@ -300,8 +300,16 @@ void PDC_gotoyx(int row, int col)
 
         chstr[0] = ch & A_CHARTEXT;
 
+        if (pdc_font_render_fast)
+        {
+            pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr,
+                                               pdc_color[foregr]);
+        }
+        else
+        {
         pdc_font = TTF_RenderUNICODE_Blended(pdc_ttffont, chstr,
                                              pdc_color[foregr]);
+        }
         if (pdc_font)
         {
             int center = pdc_fwidth > pdc_font->w ?
@@ -423,8 +431,16 @@ void _new_packet(attr_t attr, int lineno, int x, int len, const chtype *srcp)
                 if (pdc_font)
                     SDL_FreeSurface(pdc_font);
 
+                if (pdc_font_render_fast)
+                {
+                    pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr,
+                                                         pdc_color[foregr]);
+                }
+                else
+                {
                 pdc_font = TTF_RenderUNICODE_Blended(pdc_ttffont, chstr,
                                                      pdc_color[foregr]);
+                }
             }
 
             if (pdc_font)
@@ -515,7 +531,7 @@ static Uint32 _blink_timer(Uint32 interval, void *param)
 
     event.type = SDL_USEREVENT;
     SDL_PushEvent(&event);
-    return(interval);
+    return (interval);
 }
 
 void PDC_blink_text(void)

--- a/sdl2/pdcdisp.c
+++ b/sdl2/pdcdisp.c
@@ -299,13 +299,13 @@ void PDC_gotoyx(int row, int col)
 
         chstr[0] = ch & A_CHARTEXT;
 
-        switch (pdc_ttf_render_mode)
+        switch (pdc_sdl_render_mode)
         {
-        case PDC_TTF_RENDER_SOLID:
+        case PDC_SDL_RENDER_SOLID:
             pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr,
                                                pdc_color[foregr]);
             break;
-        case PDC_TTF_RENDER_SHADED:
+        case PDC_SDL_RENDER_SHADED:
             pdc_font = TTF_RenderUNICODE_Shaded(pdc_ttffont, chstr,
                                                 pdc_color[foregr], pdc_color[backgr]);
             break;
@@ -435,13 +435,13 @@ void _new_packet(attr_t attr, int lineno, int x, int len, const chtype *srcp)
                 if (pdc_font)
                     SDL_FreeSurface(pdc_font);
 
-                switch (pdc_ttf_render_mode)
+                switch (pdc_sdl_render_mode)
                 {
-                case PDC_TTF_RENDER_SOLID:
+                case PDC_SDL_RENDER_SOLID:
                     pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr,
                                                        pdc_color[foregr]);
                     break;
-                case PDC_TTF_RENDER_SHADED:
+                case PDC_SDL_RENDER_SHADED:
                     pdc_font = TTF_RenderUNICODE_Shaded(pdc_ttffont, chstr,
                                                         pdc_color[foregr], pdc_color[backgr]);
                     break;

--- a/sdl2/pdcdisp.c
+++ b/sdl2/pdcdisp.c
@@ -22,7 +22,6 @@ static chtype oldch = (chtype)(-1);    /* current attribute */
 static int rectcount = 0;              /* index into uprect */
 static int foregr = -2, backgr = -2; /* current foreground, background */
 static bool blinked_off = FALSE;
-
 /* do the real updates on a delay */
 
 void PDC_update_rects(void)
@@ -139,8 +138,8 @@ static void _set_attr(chtype ch)
     }
 }
 
-#ifdef PDC_WIDE
 
+#ifdef PDC_WIDE
 /* Draw some of the ACS_* "graphics" */
 
 bool _grprint(chtype ch, SDL_Rect dest)
@@ -300,16 +299,21 @@ void PDC_gotoyx(int row, int col)
 
         chstr[0] = ch & A_CHARTEXT;
 
-        if (pdc_font_render_fast)
+        switch (pdc_ttf_render_mode)
         {
+        case PDC_TTF_RENDER_SOLID:
             pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr,
                                                pdc_color[foregr]);
+            break;
+        case PDC_TTF_RENDER_SHADED:
+            pdc_font = TTF_RenderUNICODE_Shaded(pdc_ttffont, chstr,
+                                                pdc_color[foregr], pdc_color[backgr]);
+            break;
+        default:
+            pdc_font = TTF_RenderUNICODE_Blended(pdc_ttffont, chstr,
+                                                 pdc_color[foregr]);
         }
-        else
-        {
-        pdc_font = TTF_RenderUNICODE_Blended(pdc_ttffont, chstr,
-                                             pdc_color[foregr]);
-        }
+
         if (pdc_font)
         {
             int center = pdc_fwidth > pdc_font->w ?
@@ -431,15 +435,19 @@ void _new_packet(attr_t attr, int lineno, int x, int len, const chtype *srcp)
                 if (pdc_font)
                     SDL_FreeSurface(pdc_font);
 
-                if (pdc_font_render_fast)
+                switch (pdc_ttf_render_mode)
                 {
+                case PDC_TTF_RENDER_SOLID:
                     pdc_font = TTF_RenderUNICODE_Solid(pdc_ttffont, chstr,
+                                                       pdc_color[foregr]);
+                    break;
+                case PDC_TTF_RENDER_SHADED:
+                    pdc_font = TTF_RenderUNICODE_Shaded(pdc_ttffont, chstr,
+                                                        pdc_color[foregr], pdc_color[backgr]);
+                    break;
+                default:
+                    pdc_font = TTF_RenderUNICODE_Blended(pdc_ttffont, chstr,
                                                          pdc_color[foregr]);
-                }
-                else
-                {
-                pdc_font = TTF_RenderUNICODE_Blended(pdc_ttffont, chstr,
-                                                     pdc_color[foregr]);
                 }
             }
 

--- a/sdl2/pdcscrn.c
+++ b/sdl2/pdcscrn.c
@@ -25,7 +25,7 @@ int pdc_font_size =
 # else
  17;
 # endif
-int pdc_font_render_fast = false;
+int pdc_ttf_render_mode = PDC_TTF_RENDER_BLENDED;
 #endif
 
 SDL_Window *pdc_window = NULL;

--- a/sdl2/pdcscrn.c
+++ b/sdl2/pdcscrn.c
@@ -25,6 +25,7 @@ int pdc_font_size =
 # else
  17;
 # endif
+int pdc_font_render_fast = false;
 #endif
 
 SDL_Window *pdc_window = NULL;

--- a/sdl2/pdcscrn.c
+++ b/sdl2/pdcscrn.c
@@ -25,7 +25,7 @@ int pdc_font_size =
 # else
  17;
 # endif
-int pdc_ttf_render_mode = PDC_TTF_RENDER_BLENDED;
+int pdc_sdl_render_mode = PDC_SDL_RENDER_BLENDED;
 #endif
 
 SDL_Window *pdc_window = NULL;

--- a/sdl2/pdcsdl.h
+++ b/sdl2/pdcsdl.h
@@ -14,11 +14,11 @@
 #ifdef PDC_WIDE
 PDCEX  TTF_Font *pdc_ttffont;
 PDCEX  int pdc_font_size;
-#define PDC_TTF_RENDER_SOLID 0x01
-#define PDC_TTF_RENDER_SHADED 0x02
-#define PDC_TTF_RENDER_BLENDED 0x03
+#define PDC_SDL_RENDER_SOLID 1
+#define PDC_SDL_RENDER_SHADED 2
+#define PDC_SDL_RENDER_BLENDED 3
 
-PDCEX int pdc_ttf_render_mode;
+PDCEX int pdc_sdl_render_mode;
 #endif
 PDCEX  SDL_Window *pdc_window;
 PDCEX  SDL_Surface *pdc_screen, *pdc_font, *pdc_icon, *pdc_back;

--- a/sdl2/pdcsdl.h
+++ b/sdl2/pdcsdl.h
@@ -14,6 +14,7 @@
 #ifdef PDC_WIDE
 PDCEX  TTF_Font *pdc_ttffont;
 PDCEX  int pdc_font_size;
+PDCEX  int pdc_font_render_fast;
 #endif
 PDCEX  SDL_Window *pdc_window;
 PDCEX  SDL_Surface *pdc_screen, *pdc_font, *pdc_icon, *pdc_back;

--- a/sdl2/pdcsdl.h
+++ b/sdl2/pdcsdl.h
@@ -14,7 +14,11 @@
 #ifdef PDC_WIDE
 PDCEX  TTF_Font *pdc_ttffont;
 PDCEX  int pdc_font_size;
-PDCEX  int pdc_font_render_fast;
+#define PDC_TTF_RENDER_SOLID 0x01
+#define PDC_TTF_RENDER_SHADED 0x02
+#define PDC_TTF_RENDER_BLENDED 0x03
+
+PDCEX int pdc_ttf_render_mode;
 #endif
 PDCEX  SDL_Window *pdc_window;
 PDCEX  SDL_Surface *pdc_screen, *pdc_font, *pdc_icon, *pdc_back;


### PR DESCRIPTION
The SDL2 version uses the 'Blended' version of the renderer, making it impossible to have pixel perfect fonts. I added a variable called `pdc_font_render_fast` which, if set, uses the 'solid' renderer, which is faster, but pixel accurate with no blending.