### PR TITLE
move -lwinmm flag from LIBSADDED to EXELIBS in wincon

### DIFF
--- a/wincon/Makefile
+++ b/wincon/Makefile
@@ -117,8 +117,8 @@ else
 endif
 	LIBCURSES = pdcurses.a
 	LIBDEPS = $(LIBOBJS) $(PDCOBJS)
-	LIBSADDED = -lwinmm
-	EXELIBS =
+	LIBSADDED =
+	EXELIBS = -lwinmm
 	CLEAN = *.a
 endif
 


### PR DESCRIPTION
This PR solves https://github.com/Bill-Gray/PDCursesMod/issues/182

Per https://github.com/Bill-Gray/PDCursesMod/issues/176, -lwinmm was added to resolve an issue in `tuidemo`. On trying to build demos with `mingw32-make.exe -f Makefile demos`, I got the following error -

```
...
gcc -O4 -Wall -pedantic -I.. -ofirework.exe ../demos/firework.c pdcurses.a
C:/TDM-GCC-64/bin/../lib/gcc/x86_64-w64-mingw32/9.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: pdcurses.a(pdcutil.o):pdcutil.c:(.text+0x13): undefined reference to `__imp_PlaySoundA'
...
``` 
Since the undefined reference comes from winmm.dll, setting EXELIBS to -lwinmm instead, makes sense. This change successfully compiled static library as well as demos

OS: Windows 10
Compiler: TDM-GCC-64