### PR TITLE
Fix Appveyor Builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -270,6 +270,7 @@ before_build:
       set "CMAKE_ARGS=-DCMAKE_TOOLCHAIN_FILE=..\cmake\watcom_open_os2v2_toolchain.cmake %CMAKE_ARGS%" &&
       set "INCLUDE=%WATCOM%\H;%WATCOM%\H\OS2;%INCLUDE%"
     ) else if "%TARGET%"=="win32" (
+      set "CMAKE_ARGS=-DCMAKE_TOOLCHAIN_FILE=..\cmake\watcom_open_win32_toolchain.cmake %CMAKE_ARGS%" &&
       set "INCLUDE=%WATCOM%\H;%WATCOM%\H\NT;%INCLUDE%"
     )
 

--- a/sdl2/sdltest.c
+++ b/sdl2/sdltest.c
@@ -10,12 +10,7 @@
 #include <stdlib.h>
 #include <time.h>
 
-/* You could #include pdcsdl.h, or just add the relevant declarations
-   here: */
-
-PDCEX SDL_Window *pdc_window;
-PDCEX SDL_Surface *pdc_screen;
-PDCEX int pdc_yoffset;
+#include "pdcsdl.h"
 
 int main(int argc, char **argv)
 {
@@ -33,8 +28,6 @@ int main(int argc, char **argv)
 #ifdef PDC_WIDE
     if( argc > 1)
     {
-         extern int pdc_sdl_render_mode;
-
          pdc_sdl_render_mode = atoi( argv[1]);
     }
 #endif


### PR DESCRIPTION
This is a follow up to #184. It fixes the issues for the Appveyor builds. It builds cleanly on Appveyor and Travis:

https://ci.appveyor.com/project/mannyamorim/pdcursesmod/builds/35602840
https://travis-ci.org/github/mannyamorim/PDCursesMod/builds/733436341

After #184 there were still 2 issue with Appveyor. The `winmm.lib` problem with Watcom and there was linker error with `sdltest.c` on MSVC. The root cause of the `winmm.lib` problem was that the `appveyor.yml` was missing the toolchain file for watcom_win32. This caused use to miss defining `WATCOM_WIN32` and caused the wrong libraries to be linked.

The linker issue with `sdltest.c` was caused by defining `pdc_sdl_render_mode` as an extern instead of using `PDCEX`. I fixed it by just removing the definitions and including the header `pdcsdl.h`.