### PR TITLE
Update Makefile.vc

### DIFF
--- a/sdl2/Makefile.vc
+++ b/sdl2/Makefile.vc
@@ -28,6 +28,10 @@ PDCURSES_WIN_H	= $(osdir)\pdcsdl.h
 
 CC		= cl.exe -nologo
 
+!ifndef PLATFORM
+PLATFORM 	= $(VSCMD_ARG_TGT_ARCH)
+!endif
+
 !ifdef DEBUG
 CFLAGS		= -Z7 -DPDCDEBUG
 LDFLAGS		= -debug -pdb:none
@@ -116,7 +120,7 @@ pdcurses.res pdcurses.obj: $(common)\pdcurses.rc
 .obj.exe:
 	$(LINK) $(LDFLAGS) $< $(LIBCURSES) $(CCLIBS)
 
-tuidemo.exe: tuidemo.obj tui.obj
+tuidemo.exe: tuidemo.obj tui.obj pdcurses.lib
 	$(LINK) $(LDFLAGS) $*.obj tui.obj $(LIBCURSES) $(CCLIBS)
 
 tui.obj: $(demodir)\tui.c $(demodir)\tui.h
@@ -125,5 +129,5 @@ tui.obj: $(demodir)\tui.c $(demodir)\tui.h
 tuidemo.obj: $(demodir)\tuidemo.c
 	$(BUILD) -Dmain=SDL_main -I$(demodir) $(demodir)\tuidemo.c
 
-sdltest.exe: sdltest.obj
+sdltest.exe: sdltest.obj pdcurses.obj pdcurses.lib
 	$(LINK) $(LDFLAGS) $*.obj $(LIBCURSES) $(LIBLIBS) $(CCLIBS)


### PR DESCRIPTION
1)
default value for `$(PLATFORM)`  is missing which leads to problem not evaluating properly path for SDL2 library folder.

Changed line to include platform based on VSCMD_ARG_TGT_ARCH value (from Developer Command Prompt for VS 2019 or x64 Native Tools Command Prompt for VS 2019) when environmental variable $(PLATFORM) is missing.

2)
also i've included missing dependencies for `sdltest.exe` and `tuidemo.exe` if `pdcurses.lib` or `pdcurses.obj` is missing
(i don't know if this behaviour is expected tho) 