### PR TITLE
wincon/wingui: use async PlaySound for PDC_beep fixing #190

### DIFF
--- a/wincon/pdcutil.c
+++ b/wincon/pdcutil.c
@@ -9,7 +9,7 @@ void PDC_beep(void)
 {
     PDC_LOG(("PDC_beep() - called\n"));
 
-    if (!PlaySound((LPCTSTR) SND_ALIAS_SYSTEMDEFAULT, NULL, SND_ALIAS_ID))
+    if (!PlaySound((LPCTSTR) SND_ALIAS_SYSTEMDEFAULT, NULL, SND_ALIAS_ID | SND_ASYNC))
         Beep(800, 200);
 }
 

--- a/wingui/pdcclip.c
+++ b/wingui/pdcclip.c
@@ -120,7 +120,7 @@ int PDC_setclipboard_raw( const char *contents, long length,
     if (!OpenClipboard(NULL))
         return PDC_CLIP_ACCESS_ERROR;
 
-    handle = GlobalAlloc(GMEM_MOVEABLE|GMEM_DDESHARE,
+    handle = GlobalAlloc(GMEM_MOVEABLE | GMEM_DDESHARE,
         (length + 1) * sizeof(TCHAR));
 
     if (!handle)

--- a/wingui/pdcutil.c
+++ b/wingui/pdcutil.c
@@ -12,7 +12,7 @@ void PDC_beep(void)
     PDC_LOG(("PDC_beep() - called\n"));
 
     LeaveCriticalSection(&PDC_cs);
-    if (!PlaySound((LPCTSTR) SND_ALIAS_SYSTEMDEFAULT, NULL, SND_ALIAS_ID))
+    if (!PlaySound((LPCTSTR) SND_ALIAS_SYSTEMDEFAULT, NULL, SND_ALIAS_ID | SND_ASYNC))
         Beep(800, 200);
     EnterCriticalSection(&PDC_cs);
 }


### PR DESCRIPTION
partially reverting 78e6949bbd304e3a41bcb687c398a0820b9100a9

I consider an interrupted sound in case of "rapid-fire" better than a "hanging screen i/o"