### PR TITLE
Implement SDL1 and SDL2 shared libraries

### DIFF
--- a/sdl1/Makefile
+++ b/sdl1/Makefile
@@ -36,6 +36,7 @@ LINK		= $(CC)
 LDFLAGS		= $(LIBCURSES) $(SLIBS)
 RANLIB		= ranlib
 LIBCURSES	= pdcurses.a
+LIBCURSES_SO	= pdcurses.so
 
 DEMOS		+= sdltest
 
@@ -43,10 +44,10 @@ DEMOS		+= sdltest
 
 all:	libs
 
-libs:	$(LIBCURSES)
+libs:	$(LIBCURSES) $(LIBCURSES_SO)
 
 clean:
-	-rm -rf *.o trace $(LIBCURSES) $(DEMOS)
+	-rm -rf *.o trace $(LIBCURSES) $(LIBCURSES_SO) $(DEMOS)
 
 demos:	$(DEMOS)
 ifneq ($(DEBUG),Y)
@@ -56,6 +57,9 @@ endif
 $(LIBCURSES) : $(LIBOBJS) $(PDCOBJS)
 	ar rv $@ $?
 	-$(RANLIB) $@
+
+$(LIBCURSES_SO) : $(LIBOBJS) $(PDCOBJS)
+	$(CC) -shared -o $@ $? $(SLIBS)
 
 $(LIBOBJS) $(PDCOBJS) : $(PDCURSES_HEADERS)
 $(PDCOBJS) : $(PDCURSES_SDL_H)

--- a/sdl1/README.md
+++ b/sdl1/README.md
@@ -9,8 +9,8 @@ Building
 
 - On *nix (including Linux), run "make" in the sdl1 directory. There is
   no configure script (yet?) for this port. This assumes a working
-  sdl-config, and GNU make. It builds the library pdcurses.a (dynamic
-  lib not implemented).
+  sdl-config, and GNU make. It builds the libraries pdcurses.a and
+  pdcurses.so.
 
 - The makefile accepts the optional parameter "DEBUG=Y", and recognizes
   the optional PDCURSES_SRCDIR environment variable, as with the console

--- a/sdl2/Makefile
+++ b/sdl2/Makefile
@@ -64,15 +64,29 @@ ifeq ($(UTF8),Y)
 	CFLAGS += -DPDC_FORCE_UTF8
 endif
 
-ifeq ($(OS)_$(DLL),Windows_NT_Y)
-	CFLAGS += -DPDC_DLL_BUILD
-	LIBEXE = $(CC)
-	LIBFLAGS = -Wl,--out-implib,pdcurses.a -shared -o
-	LIBCURSES = pdcurses.dll
-	CLEAN = $(LIBCURSES) *.a
-	RESOURCE = pdcurses.o
-	LIBLIBS = $(SLIBS)
-	LDFLAGS = $(LIBCURSES)
+ifeq ($(DLL),Y)
+	ifeq ($(OS),Windows_NT)
+		CFLAGS += -DPDC_DLL_BUILD
+		LIBEXE = $(CC)
+		LIBFLAGS = -Wl,--out-implib,pdcurses.a -shared -o
+		LIBCURSES = pdcurses.dll
+		CLEAN = $(LIBCURSES) *.a
+		RESOURCE = pdcurses.o
+		LIBLIBS = $(SLIBS)
+		LDFLAGS = $(LIBCURSES)
+	else
+		ifeq ($(shell uname -s),Darwin)
+			DLL_SUFFIX = .dylib
+		else
+			DLL_SUFFIX = .so
+		endif
+		LIBEXE = $(CC)
+		LIBFLAGS = -shared -o
+		LIBCURSES = pdcurses$(DLL_SUFFIX)
+		LIBLIBS = $(SLIBS)
+		LDFLAGS = $(LIBCURSES)
+		CLEAN = *$(DLL_SUFFIX)
+	endif
 else
 	LIBEXE = $(AR)
 	LIBFLAGS = rcv

--- a/sdl2/README.md
+++ b/sdl2/README.md
@@ -10,7 +10,7 @@ Building
 - On *nix (including Linux and Mac OS X), run "make" in the sdl2
   directory. There is no configure script (yet?) for this port. This
   assumes a working sdl-config, and GNU make. It builds the library
-  pdcurses.a (dynamic lib not implemented).
+  pdcurses.a (or pdcurses.so/pdcurses.dylib with DLL=Y).
 
 - With MinGW, edit the Makefile to point to the appropriate include and
   library paths, and then run "mingw32-make".
@@ -23,9 +23,10 @@ Building
   characters, but depends on the SDL2_ttf library, instead of using
   simple bitmap fonts. "UTF8=Y" makes PDCurses ignore the system locale,
   and treat all narrow-character strings as UTF-8; this option has no
-  effect unless WIDE=Y is also set. Under Windows, you can specify
-  "DLL=Y" to build pdcurses.dll instead a static library. And on all
-  platforms, add the target "demos" to build the sample programs.
+  effect unless WIDE=Y is also set. You can specify "DLL=Y" to build a dynamic
+  rather than static library. The dynamic library is called pdcurses.dll,
+  pdcurses.so, or pdcurses.dylib on Windows, Linux, or Mac OS X respectively.
+  And on all platforms, add the target "demos" to build the sample programs.
 
 
 Usage


### PR DESCRIPTION
* SDL1: `make libs` now makes pdcurses.so in addition to pdcurses.a.
* SDL2: You can build pdcurses.so/pdcurses.dylib with make `DLL=Y`. You can only build either pdcurses.a or pdcurses.so, consistent with the rest of the Makefile.

These changes are the same as those of the PR I made on PDCurses.