### PR TITLE
VT: Make SIGWINCH register with is_termresized

### DIFF
--- a/vt/pdcscrn.c
+++ b/vt/pdcscrn.c
@@ -197,6 +197,8 @@ static void sigwinchHandler( int sig)
          PDC_rows = ws.ws_row;
          PDC_cols = ws.ws_col;
          PDC_resize_occurred = TRUE;
+         if (SP)
+            SP->resized = TRUE;
          }
 }
 


### PR DESCRIPTION
I have an application which does resizing like this:
```c
if (is_termresized()) resize_term(0, 0);
```
I had to make the change contained in this PR for the application to detect resizing using the vt backend. I don't know if the NULL check is necessary, but without it, it seems there could be a crash if the screen is resized right after `delscreen` is called.

This is mostly unrelated, but I think there is also unsafety in the signal handlers:
* `errno` should probably be saved and restored in the `SIGWINCH` handler in case `ioctl` fails.
* I don't know how to fix it, but the `SIGINT` handler calls `PDC_scr_close`, which calls `printf`. According to [this](https://man7.org/linux/man-pages/man7/signal-safety.7.html), `printf` is not safe inside signal handlers.