### PR TITLE
Fix SDL2 redrawing issue on Ubuntu MATE

### DIFF
--- a/sdl2/pdcdisp.c
+++ b/sdl2/pdcdisp.c
@@ -612,7 +612,8 @@ void PDC_pump_and_peep(void)
     {
         if (SDL_WINDOWEVENT == event.type &&
             (SDL_WINDOWEVENT_RESTORED == event.window.event ||
-             SDL_WINDOWEVENT_EXPOSED == event.window.event))
+             SDL_WINDOWEVENT_EXPOSED == event.window.event ||
+             SDL_WINDOWEVENT_SHOWN == event.window.event))
         {
             SDL_UpdateWindowSurface(pdc_window);
             rectcount = 0;


### PR DESCRIPTION
(This is the same change as in my PR for the original PDCurses. The following text is copied from that PR.)

I was having an issue when using Ubuntu MATE (but not GNOME Desktop): After a non-maximized window is minimized, it is not redrawn when it is restored. The window appears transparent until something causes it to redraw, e.g. the user resizing it. The change I have made fixes this.

I'm not exactly sure why this was an issue, but I think MATE might not be sending an `Expose` event, so this SDL code doesn't trigger: https://github.com/libsdl-org/SDL/blob/34ecd71e80b651c9840f60d91be60e30305fdc6f/src/video/x11/SDL_x11events.c#L1166. I was looking at where `SDL_WINDOWEVENT_SHOWN` is sent, and I think this is the place: https://github.com/libsdl-org/SDL/blob/34ecd71e80b651c9840f60d91be60e30305fdc6f/src/video/x11/SDL_x11events.c#L437. It's send alongside `SDL_WINDOWEVENT_RESTORED`, but it looks like `SDL_WINDOWEVENT_RESTORED` has no effect since the window is not maximized in this case: https://github.com/libsdl-org/SDL/blob/34ecd71e80b651c9840f60d91be60e30305fdc6f/src/events/SDL_windowevents.c#L142. I haven't verified this explanation, but it would explain why neither `SDL_WINDOWEVENT_EXPOSED` nor `SDL_WINDOWEVENT_RESTORED` is sent to PDCurses.