### PR TITLE
Fix non-wide sdl2 font coloration

### DIFF
--- a/sdl2/pdcscrn.c
+++ b/sdl2/pdcscrn.c
@@ -260,7 +260,10 @@ int PDC_scr_open(void)
     SP->mono = FALSE;
 #else
     if (pdc_font)
-        pdc_flastc = pdc_font->format->palette->ncolors - 1;
+    {
+        if (pdc_font->format->palette)
+            pdc_flastc = pdc_font->format->palette->ncolors - 1;
+    }
     else
     {
         int palette_size;

--- a/sdl2/pdcscrn.c
+++ b/sdl2/pdcscrn.c
@@ -263,19 +263,25 @@ int PDC_scr_open(void)
         pdc_flastc = pdc_font->format->palette->ncolors - 1;
     else
     {
-        const char *fname = getenv("PDC_FONT");
-        SDL_RWops *bmp_rw = SDL_RWFromFile(fname ? fname : "pdcfont.bmp", "r");
-        if (!bmp_rw)
-            bmp_rw = SDL_RWFromMem(font437, sizeof(font437));
+        int palette_size;
 
-        pdc_font = _load_bmp_and_palette_size(bmp_rw, &pdc_flastc);
-        pdc_flastc--;
+        const char *fname = getenv("PDC_FONT");
+        SDL_RWops *file = SDL_RWFromFile(fname ? fname : "pdcfont.bmp", "r");
+        if (file)
+            pdc_font = _load_bmp_and_palette_size(file, &palette_size);
+
+        if (!pdc_font)
+            pdc_font = _load_bmp_and_palette_size(
+                SDL_RWFromMem(font437, sizeof(font437)), &palette_size);
 
         if (!pdc_font)
         {
             fprintf(stderr, "Could not load font\n");
             return ERR;
         }
+
+        if (pdc_font->format->palette)
+            pdc_flastc = palette_size - 1;
     }
 
     SP->mono = !pdc_font->format->palette;


### PR DESCRIPTION
I'm not sure when SDL2 started doing this, but I noticed the behavior with version 2.0.14. It seems like the palette size of a loaded bitmap surface is larger than the palette size of the actual bitmap. Therefore, the last color in the in-memory palette never actually shows up in the font. This leads to characters not being properly colored.

This patch adds some complex code because it needs to parse part of the bitmap file itself. A much simpler way to fix this issue would be to use the first and second palette entries rather than the first and last, but doing so might break user code.

Following is a modified version of the built-in font. It has 16 colors in its palette, although only 3 are used. Using it as the `PDC_FONT` with the `testcurs` program, you can see that the red in the A and B is preserved, as it should be, across different text attribute combinations.

[modified437.bmp.gz](https://github.com/Bill-Gray/PDCursesMod/files/6642933/modified437.bmp.gz)
