### PR TITLE
Improve x11 font compatibility

### DIFF
--- a/x11/pdcscrn.c
+++ b/x11/pdcscrn.c
@@ -520,22 +520,19 @@ int PDC_scr_open(void)
 
     /* Check application resource values here */
 
-    pdc_fwidth = pdc_app_data.normalFont->max_bounds.rbearing -
-                 pdc_app_data.normalFont->min_bounds.lbearing;
+    pdc_fwidth = pdc_app_data.normalFont->max_bounds.width;
 
-    pdc_fascent = pdc_app_data.normalFont->max_bounds.ascent;
-    pdc_fdescent = pdc_app_data.normalFont->max_bounds.descent;
+    pdc_fascent = pdc_app_data.normalFont->ascent;
+    pdc_fdescent = pdc_app_data.normalFont->descent;
     pdc_fheight = pdc_fascent + pdc_fdescent;
 
     /* Check that the italic font and normal fonts are the same size */
 
     italic_font_valid = pdc_fwidth ==
-        pdc_app_data.italicFont->max_bounds.rbearing -
-        pdc_app_data.italicFont->min_bounds.lbearing;
+        pdc_app_data.italicFont->max_bounds.width;
 
     bold_font_valid = pdc_fwidth ==
-        pdc_app_data.boldFont->max_bounds.rbearing -
-        pdc_app_data.boldFont->min_bounds.lbearing;
+        pdc_app_data.boldFont->max_bounds.width;
 
     /* Calculate size of display window */
 


### PR DESCRIPTION
These changes to the font width/height calculation make it match the calculation used by `XDrawImageString` more closely, although I haven't been able to find a whole lot of documentation on the subject. This PR is necessary to make some fonts such as `lucidasanstypewriter-*` work. Furthermore, according to my testing, this PR is necessary to make the default XCurses configuration work on Raspbian/LXDE. On this system, the default XCurses font is not available, so a fallback font is used (although I'm unsure what it is exactly.) Without this patch, the fallback font doesn't work.

Here are some pictures of the bug:

With the Raspbian/LXDE fallback font:
![2021-06-17-114340_960x408](https://user-images.githubusercontent.com/28828704/122413176-2cc14c00-cf54-11eb-8b50-534d75b0768a.png)

With `lucidasanstypewriter-10`:
![2021-06-17-130326_880x384](https://user-images.githubusercontent.com/28828704/122413177-2cc14c00-cf54-11eb-80b7-b5107e3cc035.png)

For some reason, the width of a font character (`max_bounds.rbearing - min_bounds.lbearing`) is sometimes larger than the space assigned to the character by `XDrawImageString`. In the first picture, you can see that `max_bounds.ascent + max_bounds.descent` is greater than the line height.