### PR TITLE
Fix resizing issues, remove multi-threaded message handling from `WinGUI` variant 

### DIFF
--- a/curses.h
+++ b/curses.h
@@ -1780,6 +1780,8 @@ PDCEX int     PDC_set_function_key( const unsigned function,
                               const int new_key);
 PDCEX int     PDC_get_function_key( const unsigned function);
 
+PDCEX void    PDC_set_window_resized_callback(void (*callback)());
+
 PDCEX  WINDOW *Xinitscr(int, char **);
 #ifdef XCURSES
 PDCEX  void    XCursesExit(void);

--- a/wingui/pdcdisp.c
+++ b/wingui/pdcdisp.c
@@ -243,7 +243,6 @@ int PDC_choose_a_new_font( void)
     CHOOSEFONT cf;
     int rval;
     extern HWND PDC_hWnd;
-    extern CRITICAL_SECTION PDC_cs;
 
     lf.lfHeight = -PDC_font_size;
     debug_printf( "In PDC_choose_a_new_font: %d\n", lf.lfHeight);
@@ -252,9 +251,7 @@ int PDC_choose_a_new_font( void)
     cf.Flags = CF_INITTOLOGFONTSTRUCT | CF_SCREENFONTS | CF_FIXEDPITCHONLY | CF_SELECTSCRIPT;
     cf.hwndOwner = PDC_hWnd;
     cf.lpLogFont = &lf;
-    LeaveCriticalSection(&PDC_cs);
     rval = ChooseFont( &cf);
-    EnterCriticalSection(&PDC_cs);
     if( rval) {
 #ifdef PDC_WIDE
         wcscpy( PDC_font_name, lf.lfFaceName);

--- a/wingui/pdckbd.c
+++ b/wingui/pdckbd.c
@@ -17,13 +17,14 @@ void PDC_set_keyboard_binary(bool on)
 extern int PDC_key_queue_low, PDC_key_queue_high;
 extern int PDC_key_queue[KEY_QUEUE_SIZE];
 
+/* PDCurses message/event callback */
+/* Calling PDC_napms for one millisecond ensures that the message loop */
+/* is called and messages in general,  and keyboard events in particular, */
+/* get processed.   */
+
 bool PDC_check_key(void)
 {
-    extern CRITICAL_SECTION PDC_cs;
-
-    LeaveCriticalSection(&PDC_cs);
-    SwitchToThread( );
-    EnterCriticalSection(&PDC_cs);
+    PDC_napms( 1);
     if( PDC_key_queue_low != PDC_key_queue_high)
         return TRUE;
     return FALSE;

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -985,6 +985,7 @@ INLINE int set_default_sizes_from_registry( const int n_cols, const int n_rows,
 static void adjust_font_size( const int font_size_change)
 {
     extern int PDC_font_size;
+    RECT client_rect;
 
     PDC_font_size += font_size_change;
     if( PDC_font_size < 2)
@@ -1001,22 +1002,21 @@ static void adjust_font_size( const int font_size_change)
           /* you disagree,  I have others.                    */
     if( IsZoomed( PDC_hWnd))
     {
-        RECT client_rect;
-        GetClientRect( PDC_hWnd, &client_rect);
+        GetClientRect(PDC_hWnd, &client_rect);
         PDC_n_rows = client_rect.bottom / PDC_cyChar;
         PDC_n_cols = client_rect.right / PDC_cxChar;
-        keep_size_within_bounds( &PDC_n_rows, &PDC_n_cols);
-        PDC_resize_screen( PDC_n_rows, PDC_n_cols);
-        add_key_to_queue( KEY_RESIZE);
+        keep_size_within_bounds(&PDC_n_rows, &PDC_n_cols);
+        PDC_resize_screen(PDC_n_rows, PDC_n_cols);
+        add_key_to_queue(KEY_RESIZE);
         SP->resized = TRUE;
-        GetClientRect( PDC_hWnd, &client_rect);
-        InvalidateRect(PDC_hWnd, &client_rect, FALSE);
     }
     else
     {
         PDC_resize_screen( PDC_n_rows, PDC_n_cols);
-        InvalidateRect( PDC_hWnd, NULL, FALSE);
     }
+
+    InvalidateRect(PDC_hWnd, NULL, FALSE);
+    UpdateWindow(PDC_hWnd);
 }
 
 #define WM_ENLARGE_FONT       (WM_USER + 1)

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -1278,79 +1278,83 @@ struct BACK_BUFFER {
     HANDLE original_object;
     RECT rect;
     bool is_rect_valid;
-} backBuffer;
+} back_buffer;
 
 static void PrepareBackBuffer(HDC hdc, RECT rect)
 {
-    memset(&backBuffer, 0, sizeof(backBuffer));
     int width = rect.right - rect.left;
     int height = rect.bottom - rect.top;
-    backBuffer.rect = rect;
-    backBuffer.window_dc = hdc;
-    backBuffer.memory_dc = CreateCompatibleDC(hdc);
-    backBuffer.memory_bitmap = CreateCompatibleBitmap(hdc, width, height);
-    backBuffer.original_object =
-        SelectObject(backBuffer.memory_dc, backBuffer.memory_bitmap);
-    backBuffer.is_rect_valid = width > 0 && height > 0;
+    memset(&back_buffer, 0, sizeof(back_buffer));
+    back_buffer.rect = rect;
+    back_buffer.window_dc = hdc;
+    back_buffer.memory_dc = CreateCompatibleDC(hdc);
+    back_buffer.memory_bitmap = CreateCompatibleBitmap(hdc, width, height);
+    back_buffer.original_object =
+        SelectObject(back_buffer.memory_dc, back_buffer.memory_bitmap);
+    back_buffer.is_rect_valid = width > 0 && height > 0;
 }
 
 static void BlitBackBuffer()
 {
-    if (backBuffer.is_rect_valid)
+    const RECT* r = NULL;
+    int width = 0;
+    int height = 0;
+
+    if (back_buffer.is_rect_valid)
     {
-        const RECT* r = &backBuffer.rect;
-        int width = r->right - r->left;
-        int height = r->bottom - r->top;
+        r = &back_buffer.rect;
+        width = r->right - r->left;
+        height = r->bottom - r->top;
         BitBlt(
-            backBuffer.window_dc,
+            back_buffer.window_dc,
             r->left, r->top,
             width, height,
-            backBuffer.memory_dc,
+            back_buffer.memory_dc,
             0, 0,
             SRCCOPY);
     }
-    SelectObject(backBuffer.memory_dc, backBuffer.original_object);
-    DeleteObject(backBuffer.memory_bitmap);
-    DeleteObject(backBuffer.memory_dc);
-    memset(&backBuffer, 0, sizeof(backBuffer));
+    SelectObject(back_buffer.memory_dc, back_buffer.original_object);
+    DeleteObject(back_buffer.memory_bitmap);
+    DeleteObject(back_buffer.memory_dc);
+    memset(&back_buffer, 0, sizeof(back_buffer));
 }
 
 static void HandlePaint( HWND hwnd )
 {
     PAINTSTRUCT ps;
-    HDC windowDC, memoryDC;
-    RECT clientRect;
+    HDC window_dc, memory_dc;
+    RECT client_rect;
+    HBRUSH hOldBrush;
 
 /*  printf( "In HandlePaint: %ld %ld, %ld %ld\n",
                rect.left, rect.top, rect.right, rect.bottom); */
 
-    windowDC = BeginPaint( hwnd, &ps);
-    GetClientRect(hwnd, &clientRect);
+    window_dc = BeginPaint( hwnd, &ps);
+    GetClientRect(hwnd, &client_rect);
 
-    PrepareBackBuffer(windowDC, clientRect);
-    memoryDC = backBuffer.memory_dc;
+    PrepareBackBuffer(window_dc, client_rect);
+    memory_dc = back_buffer.memory_dc;
     {
         /* paint the background black. */
-        const HBRUSH hOldBrush =
-            SelectObject(memoryDC, GetStockObject(BLACK_BRUSH));
-        Rectangle(memoryDC,
-            clientRect.left, clientRect.top,
-            clientRect.right, clientRect.bottom);
-        SelectObject(memoryDC, hOldBrush);
+        hOldBrush = SelectObject(memory_dc, GetStockObject(BLACK_BRUSH));
+        Rectangle(memory_dc,
+            client_rect.left, client_rect.top,
+            client_rect.right, client_rect.bottom);
+        SelectObject(memory_dc, hOldBrush);
 
         /* paint all the rows */
         if (curscr && curscr->_y)
         {
             int i, x1, n_chars;
 
-            x1 = clientRect.left / PDC_cxChar;
-            n_chars = clientRect.right / PDC_cxChar - x1 + 1;
+            x1 = client_rect.left / PDC_cxChar;
+            n_chars = client_rect.right / PDC_cxChar - x1 + 1;
             if (n_chars > SP->cols - x1)
                 n_chars = SP->cols - x1;
             if (n_chars > 0)
-                for (i = clientRect.top / PDC_cyChar; i <= clientRect.bottom / PDC_cyChar; i++)
+                for (i = client_rect.top / PDC_cyChar; i <= client_rect.bottom / PDC_cyChar; i++)
                     if (i < SP->lines && curscr->_y[i])
-                        PDC_transform_line_given_hdc(memoryDC, i, x1,
+                        PDC_transform_line_given_hdc(memory_dc, i, x1,
                             n_chars, curscr->_y[i] + x1);
         }
     }

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -4,7 +4,6 @@
 #include <tchar.h>
 #include <stdint.h>
 #include <assert.h>
-#include <process.h>
 #include "../common/pdccolor.h"
 #ifdef WIN32_LEAN_AND_MEAN
    #ifdef PDC_WIDE
@@ -67,7 +66,7 @@ cube of 16 million colors. */
 int PDC_show_ctrl_alts = 0;
 
 /* RR: Removed statis on next line */
-/*bool PDC_bDone = FALSE;*/
+bool PDC_bDone = FALSE;
 static HWND originally_focussed_window;
 
 int debug_printf( const char *format, ...)
@@ -105,8 +104,6 @@ int debug_printf( const char *format, ...)
 HWND PDC_hWnd;
 static int PDC_argc = 0;
 static char **PDC_argv = NULL;
-uint32_t winthr_id = 0;
-CRITICAL_SECTION PDC_cs;
 
 static void final_cleanup( void)
 {
@@ -143,7 +140,7 @@ void PDC_scr_close(void)
 {
     PDC_LOG(("PDC_scr_close() - called\n"));
     final_cleanup( );
-    /*PDC_bDone = TRUE;*/
+    PDC_bDone = TRUE;
 }
 
 /* NOTE that PDC_scr_free( ) is called only from delscreen( ),    */
@@ -1149,7 +1146,7 @@ static int keep_size_within_bounds( int *lines, int *cols)
 }
 
 INLINE int get_default_sizes_from_registry( int *n_cols, int *n_rows,
-                                     int *xloc, int *yloc)
+                                     int *xloc, int *yloc, int *menu_shown)
 {
     TCHAR data[100];
     DWORD size_out = sizeof( data);
@@ -1170,18 +1167,15 @@ INLINE int get_default_sizes_from_registry( int *n_cols, int *n_rows,
         {
             extern int PDC_font_size;
             int x = -1, y = -1, bytes_read = 0;
-            int minl = 0, maxl = 0, minc = 0, maxc = 0;
 
             my_stscanf( data, _T( "%dx%d,%d,%d,%d,%d;%d,%d,%d,%d:%n"),
                              &x, &y, &PDC_font_size,
-                             xloc, yloc, &menu_shown,
-                             &minl, &maxl,
-                             &minc, &maxc,
+                             xloc, yloc, menu_shown,
+                             &min_lines, &max_lines,
+                             &min_cols, &max_cols,
                              &bytes_read);
             if( bytes_read > 0 && data[bytes_read - 1] == ':')
                my_tcscpy( PDC_font_name, data + bytes_read);
-            if ( !resize_limits_set)
-                PDC_set_resize_limits(minl, maxl, minc, maxc);
             if( n_cols)
                 *n_cols = x;
             if( n_rows)
@@ -1552,7 +1546,6 @@ int PDC_get_mouse_event_from_queue( void)
 
     if( !n_mouse_queue)
         return( -1);
-    EnterCriticalSection(&PDC_cs);
     memset(&SP->mouse_status, 0, sizeof(MOUSE_STATUS));
     if( mouse_queue->action == BUTTON_MOVED)
     {
@@ -1583,7 +1576,6 @@ int PDC_get_mouse_event_from_queue( void)
         SP->mouse_status.button[i] |= mouse_queue->button_flags;
     n_mouse_queue--;
     memmove( mouse_queue, mouse_queue + 1, n_mouse_queue * sizeof( PDC_mouse_event));
-    LeaveCriticalSection(&PDC_cs);
     return( 0);
 }
 
@@ -1716,6 +1708,11 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
     static bool ignore_resize = FALSE;
     int button = -1, action = -1;
 
+    PDC_hWnd = hwnd;
+    if( !hwnd)
+        debug_printf( "Null hWnd: msg %u, wParam %x, lParam %lx\n",
+                     message, wParam, lParam);
+
     switch (message)
     {
     case WM_SIZING:
@@ -1725,16 +1722,12 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
     case WM_SIZE:
                 /* If ignore_resize = 1,  don't bother resizing; */
                 /* the final window size has yet to be set       */
-        if( ignore_resize == FALSE) {
-            EnterCriticalSection(&PDC_cs);
-            HandleSize( wParam, lParam);
-            LeaveCriticalSection(&PDC_cs);
-        }
+        if( ignore_resize == FALSE)
+           HandleSize( wParam, lParam);
         return 0 ;
 
     case WM_MOUSEWHEEL:
     case WM_MOUSEHWHEEL:
-        EnterCriticalSection(&PDC_cs);
         {
             static int mouse_wheel_vertical_loc = 0;
             static int mouse_wheel_horizontal_loc = 0;
@@ -1776,18 +1769,14 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
                 }
             }
         }
-        LeaveCriticalSection(&PDC_cs);
         return 0;
 
     case WM_MOUSEMOVE:
         {
         const int mouse_x = LOWORD( lParam) / PDC_cxChar;
         const int mouse_y = HIWORD( lParam) / PDC_cyChar;
-
-        EnterCriticalSection(&PDC_cs);
         if( add_mouse( 0, BUTTON_MOVED, mouse_x, mouse_y))
             modified_key_to_return = 0;
-        LeaveCriticalSection(&PDC_cs);
         }
         return 0;
 
@@ -1850,14 +1839,11 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
       /* refresh.c.  I'm not entirely sure that this is what ought to be  */
       /* done,  though it does appear to work correctly.                  */
     case WM_PAINT:
-        EnterCriticalSection(&PDC_cs);
         HandlePaint( hwnd );
-        LeaveCriticalSection(&PDC_cs);
         return 0;
 
     case WM_KEYUP:
     case WM_SYSKEYUP:
-        EnterCriticalSection(&PDC_cs);
         if( wParam == VK_MENU && numpad_unicode_value)
         {
             modified_key_to_return = numpad_unicode_value;
@@ -1868,30 +1854,24 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
         {
             add_key_to_queue( modified_key_to_return );
             modified_key_to_return = 0;
-            LeaveCriticalSection(&PDC_cs);
             return 0;
         }
-        LeaveCriticalSection(&PDC_cs);
         return DefWindowProc(hwnd, message, wParam, lParam);
 
     case WM_CHAR:       /* _Don't_ add Shift-Tab;  it's handled elsewhere */
-        EnterCriticalSection(&PDC_cs);
         if( wParam == 3 && !SP->raw_inp)     /* Ctrl-C hit */
             exit( 0);
         if( wParam != 9 || !(GetKeyState( VK_SHIFT) & 0x8000))
             if( !key_already_handled)
                add_key_to_queue( (int)wParam );
         key_already_handled = FALSE;
-        LeaveCriticalSection(&PDC_cs);
         return 0;
 
     case WM_KEYDOWN:
     case WM_SYSKEYDOWN:
         if( wParam < 225 && wParam > 0 )
         {
-            EnterCriticalSection(&PDC_cs);
             HandleSyskeyDown( wParam, lParam, &modified_key_to_return );
-            LeaveCriticalSection(&PDC_cs);
             return 0;
         }
         return DefWindowProc(hwnd, message, wParam, lParam);
@@ -1900,7 +1880,6 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
         return 0 ;
 
     case WM_TIMER:
-        EnterCriticalSection(&PDC_cs);
         if( wParam != TIMER_ID_FOR_BLINKING)
         {
             KillTimer( PDC_hWnd, (int)wParam);
@@ -1911,11 +1890,9 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
             /* blink the blinking text */
             HandleTimer( wParam );
         }
-        LeaveCriticalSection(&PDC_cs);
         return 0;
 
     case WM_CLOSE:
-        EnterCriticalSection(&PDC_cs);
         if( !PDC_get_function_key( FUNCTION_KEY_SHUT_DOWN))
         {
             final_cleanup( );
@@ -1924,68 +1901,61 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
         }
         else
             add_key_to_queue( PDC_get_function_key( FUNCTION_KEY_SHUT_DOWN));
-
-        LeaveCriticalSection(&PDC_cs);
-        return( 0);
+        return 0;
 
     case WM_COMMAND:
     case WM_SYSCOMMAND:
         if( wParam == WM_EXIT_GRACELESSLY)
         {
-            EnterCriticalSection(&PDC_cs);
             final_cleanup( );
-            /*PDC_bDone = TRUE;*/
+            PDC_bDone = TRUE;
             exit( 0);
         }
         else if( wParam == WM_ENLARGE_FONT || wParam == WM_SHRINK_FONT)
         {
-            EnterCriticalSection(&PDC_cs);
             adjust_font_size( (wParam == WM_ENLARGE_FONT) ? 1 : -1);
-            LeaveCriticalSection(&PDC_cs);
             return( 0);
         }
         else if( wParam == WM_CHOOSE_FONT)
         {
-            EnterCriticalSection(&PDC_cs);
             if( PDC_choose_a_new_font( ))
                 adjust_font_size( 0);
-            LeaveCriticalSection(&PDC_cs);
             return( 0);
         }
         else if( wParam == WM_TOGGLE_MENU)
         {
-            EnterCriticalSection(&PDC_cs);
             HandleMenuToggle( &ignore_resize);
-            LeaveCriticalSection(&PDC_cs);
             return 0;
         }
         return DefWindowProc(hwnd, message, wParam, lParam);
 
     case WM_DESTROY:
-        EnterCriticalSection(&PDC_cs);
         PDC_LOG(("WM_DESTROY\n"));
         PostQuitMessage (0) ;
-        /*PDC_bDone = TRUE;*/
-        LeaveCriticalSection(&PDC_cs);
+        PDC_bDone = TRUE;
         return 0 ;
+    }
 
-    default:
-        return DefWindowProc( hwnd, message, wParam, lParam) ;
+    if( button != -1)
+    {
+        add_mouse( button, action, LOWORD( lParam) / PDC_cxChar, HIWORD( lParam) / PDC_cyChar);
+        if( action == BUTTON_PRESSED)
+           SetCapture( hwnd);
+        else
+           ReleaseCapture( );
+#if 0 /* checkme */
+        SetTimer( hwnd, 0, SP->mouse_wait, NULL);
+#endif
     }
 
     /* mouse button handling code */
-    assert( button != -1);
-    EnterCriticalSection(&PDC_cs);
 
     add_mouse( button, action, LOWORD( lParam) / PDC_cxChar, HIWORD( lParam) / PDC_cyChar);
     if( action == BUTTON_PRESSED)
        SetCapture( hwnd);
     else
-       ReleaseCapture( );
-    SetTimer( hwnd, 0, SP->mouse_wait, NULL);
-
-    LeaveCriticalSection(&PDC_cs);
-    return 0;
+       add_mouse( -1, -1, -1, -1);
+    return DefWindowProc( hwnd, message, wParam, lParam) ;
 }
 
 /* https://msdn.microsoft.com/en-us/library/windows/desktop/dd162826(v=vs.85).aspx
@@ -2030,79 +2000,6 @@ static void clip_or_center_window_to_monitor( HWND hwnd)
 }
 #endif
 
-struct PDC_WININFO {
-    HANDLE hInstance;
-    int xsize;
-    int ysize;
-    DWORD window_style;
-    DWORD window_ex_style;
-    int xloc;
-    int yloc;
-    TCHAR WindowTitle[MAX_PATH];
-};
-
-static const TCHAR *AppName = _T( "Curses_App");
-static HANDLE winthr_ready;
-
-/* Thread that creates and manages the WinGUI window.
-   The return type (and declared type of winthr_id) is uint32_t instead of
-   DWORD to avoid compiler warnings. */
-
-static uint32_t WINAPI window_thread(LPVOID lpParameter)
-{
-    MSG msg;
-    HMENU hMenu;
-    struct PDC_WININFO *winfo = (struct PDC_WININFO *) lpParameter;
-    BOOL rval;
-
-    PDC_hWnd = CreateWindowEx(winfo->window_ex_style, AppName,
-                    winfo->WindowTitle, winfo->window_style,
-                    winfo->xloc, winfo->yloc,
-                    winfo->xsize, winfo->ysize,
-                    NULL, (menu_shown ? set_menu( ) : NULL),
-                    winfo->hInstance, NULL) ;
-
-    if( !PDC_hWnd)
-    {
-        const DWORD last_error = GetLastError( );
-
-        debug_printf( "CreateWindow failed; GetLastError = %ld", last_error);
-        return( 2);
-    }
-
-    hMenu = GetSystemMenu( PDC_hWnd, FALSE);
-    AppendMenu( hMenu, MF_STRING | (menu_shown ? MF_CHECKED : MF_UNCHECKED), WM_TOGGLE_MENU, _T( "Menu"));
-    AppendMenu( hMenu, MF_STRING, WM_CHOOSE_FONT, _T( "Choose Font"));
-
-    debug_printf( "menu set\n");
-
-    ShowWindow (PDC_hWnd,
-                    (winfo->window_style & WS_MAXIMIZE) ? SW_SHOWMAXIMIZED : SW_SHOWNORMAL);
-    debug_printf( "window shown\n");
-    UpdateWindow (PDC_hWnd) ;
-    debug_printf( "window updated\n");
-    SetTimer( PDC_hWnd, TIMER_ID_FOR_BLINKING, 500, NULL);
-    debug_printf( "timer set\n");
-
-#if defined( MONITOR_DEFAULTTONEAREST) && WINVER >= 0x0410
-    /* if the window is off-screen, move it on screen. */
-    clip_or_center_window_to_monitor( PDC_hWnd);
-#endif
-
-    SetEvent(winthr_ready);
-
-    while ((rval = GetMessage(&msg, NULL, 0, 0)) == TRUE) {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
-    }
-
-    if (rval == -1) {
-        debug_printf("GetMessage() error: GetLastError = %lu\n", GetLastError());
-        return 1;
-    }
-    return 0;
-}
-
 /* By default,  the user cannot resize the window.  This is because
 many apps don't handle KEY_RESIZE,  and one can get odd behavior
 in such cases.  There are two ways around this.  If you call
@@ -2127,33 +2024,29 @@ INLINE int set_up_window( void)
 {
     /* create the dialog window  */
     WNDCLASS   wndclass ;
+    HMENU hMenu;
     HANDLE hInstance = GetModuleHandle( NULL);
     int n_default_columns = 80;
     int n_default_rows = 25;
-    struct PDC_WININFO winfo;
+    int xsize, ysize, window_style;
+    int xloc = CW_USEDEFAULT;
+    int yloc = CW_USEDEFAULT;
+    TCHAR WindowTitle[MAX_PATH];
+    const TCHAR *AppName = _T( "Curses_App");
     HICON icon;
-    /*static bool wndclass_has_been_registered = FALSE;*/
-    HANDLE winthr_h;
-    HANDLE hWait[2];
-    DWORD winthr_status;
+    static bool wndclass_has_been_registered = FALSE;
 
     if( !hInstance)
         debug_printf( "No instance: %d\n", GetLastError( ));
-
-    winfo.hInstance = hInstance;
-    winfo.xloc = CW_USEDEFAULT;
-    winfo.yloc = CW_USEDEFAULT;
-
     originally_focussed_window = GetForegroundWindow( );
     debug_printf( "hInstance %x\nOriginal window %x\n", hInstance, originally_focussed_window);
-    /*if( !wndclass_has_been_registered)*/
+    /* set the window icon from the icon in the process */
+    icon = get_app_icon(hInstance);
+    if( !icon )
+       icon = LoadIcon( NULL, IDI_APPLICATION);
+    if( !wndclass_has_been_registered)
     {
         ATOM rval;
-
-        /* set the window icon from the icon in the process */
-        icon = get_app_icon(hInstance);
-        if( !icon )
-           icon = LoadIcon( NULL, IDI_APPLICATION);
 
         wndclass.style         = CS_VREDRAW ;
         wndclass.lpfnWndProc   = WndProc ;
@@ -2174,76 +2067,84 @@ INLINE int set_up_window( void)
             debug_printf( "RegisterClass failed: GetLastError = %lx\n", last_error);
             return( -1);
         }
-        /*wndclass_has_been_registered = TRUE;*/
+        wndclass_has_been_registered = TRUE;
     }
 
-    get_app_name( winfo.WindowTitle, MAX_PATH, TRUE);
+    get_app_name( WindowTitle, MAX_PATH, TRUE);
 #ifdef PDC_WIDE
-    debug_printf( "WindowTitle = '%ls'\n", winfo.WindowTitle);
+    debug_printf( "WindowTitle = '%ls'\n", WindowTitle);
 #endif
 
-    get_default_sizes_from_registry( &n_default_columns, &n_default_rows,
-                                     &winfo.xloc, &winfo.yloc);
     if( PDC_n_rows > 2 && PDC_n_cols > 2)
     {
         n_default_columns = PDC_n_cols;
         n_default_rows    = PDC_n_rows;
     }
+
+    get_default_sizes_from_registry( &n_default_columns, &n_default_rows,
+                     &xloc, &yloc, &menu_shown);
+
     if( ttytype[1])
         PDC_set_resize_limits( (unsigned char)ttytype[0],
                                (unsigned char)ttytype[1],
                                (unsigned char)ttytype[2],
                                (unsigned char)ttytype[3]);
     debug_printf( "Size %d x %d,  loc %d x %d;  menu %d\n",
-               n_default_columns, n_default_rows, winfo.xloc, winfo.yloc, menu_shown);
+               n_default_columns, n_default_rows, xloc, yloc, menu_shown);
     get_character_sizes( NULL, &PDC_cxChar, &PDC_cyChar);
 
     if( min_lines != max_lines || min_cols != max_cols)
-        winfo.window_style = ((n_default_columns == -1) ?
+        window_style = ((n_default_columns == -1) ?
                     WS_MAXIMIZE | WS_OVERLAPPEDWINDOW : WS_OVERLAPPEDWINDOW);
     else  /* fixed-size window:  looks "normal",  but w/o a maximize box */
-        winfo.window_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
+        window_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
 
-    winfo.window_ex_style = WS_EX_CLIENTEDGE;
+    DWORD window_ex_style = WS_EX_CLIENTEDGE;
 
     if( n_default_columns == -1)
-        winfo.xsize = winfo.ysize = CW_USEDEFAULT;
+        xsize = ysize = CW_USEDEFAULT;
     else
     {
         keep_size_within_bounds( &n_default_rows, &n_default_columns);
-        winfo.xsize = PDC_cxChar * n_default_columns;
-        winfo.ysize = PDC_cyChar * n_default_rows;
-        adjust_window_size( &winfo.xsize, &winfo.ysize, winfo.window_style,
-                                        winfo.window_ex_style);
+        xsize = PDC_cxChar * n_default_columns;
+        ysize = PDC_cyChar * n_default_rows;
+        adjust_window_size( &xsize, &ysize, window_style, menu_shown);
     }
 
-    InitializeCriticalSection(&PDC_cs);
-    winthr_ready = CreateEvent(NULL, FALSE, FALSE, NULL);
-    winthr_h = (HANDLE) _beginthreadex(NULL, 0, window_thread, &winfo, 0, &winthr_id);
-    if (winthr_h == (HANDLE) 0) {
-        debug_printf("_beginthreadex() failed: %s\n", strerror(errno));
-        DeleteCriticalSection(&PDC_cs);
-        CloseHandle(winthr_ready);
-        CloseHandle(winthr_h);
-        return -1;
+    PDC_hWnd = CreateWindowEx( window_ex_style,
+                    AppName, WindowTitle,
+                    window_style,
+                    xloc, yloc,
+                    xsize, ysize,
+                    NULL, (menu_shown ? set_menu( ) : NULL),
+                    hInstance, NULL) ;
+
+    if( !PDC_hWnd)
+    {
+        const DWORD last_error = GetLastError( );
+
+        debug_printf( "CreateWindow failed; GetLastError = %ld", last_error);
+        return( -2);
     }
 
-    hWait[0] = winthr_ready;
-    hWait[1] = winthr_h;
-    WaitForMultipleObjects(2, hWait, FALSE, INFINITE);
-    CloseHandle(winthr_ready);
-    if (!GetExitCodeThread(winthr_h, &winthr_status)) {
-        debug_printf("GetExitCodeThread() failed: GetLastError = %lu\n", GetLastError());
-        DeleteCriticalSection(&PDC_cs);
-        CloseHandle(winthr_h);
-        return -1;
-    }
-    CloseHandle(winthr_h);
-    if (winthr_status != STILL_ACTIVE) {
-        debug_printf("Premature window_thread termination: exit code = %lu\n", winthr_status);
-        DeleteCriticalSection(&PDC_cs);
-        return winthr_status;
-    }
+    hMenu = GetSystemMenu( PDC_hWnd, FALSE);
+    AppendMenu( hMenu, MF_STRING | (menu_shown ? MF_CHECKED : MF_UNCHECKED), WM_TOGGLE_MENU, _T( "Menu"));
+    AppendMenu( hMenu, MF_STRING, WM_CHOOSE_FONT, _T( "Choose Font"));
+
+    debug_printf( "menu set\n");
+
+    ShowWindow (PDC_hWnd,
+                    (n_default_columns == -1) ? SW_SHOWMAXIMIZED : SW_SHOWNORMAL);
+    debug_printf( "window shown\n");
+    UpdateWindow (PDC_hWnd) ;
+    debug_printf( "window updated\n");
+    SetTimer( PDC_hWnd, TIMER_ID_FOR_BLINKING, 500, NULL);
+    debug_printf( "timer set\n");
+
+#if defined( MONITOR_DEFAULTTONEAREST) && WINVER >= 0x0410
+    /* if the window is off-screen, move it on screen. */
+    clip_or_center_window_to_monitor( PDC_hWnd);
+#endif
 
     return( 0);
 }
@@ -2303,8 +2204,6 @@ int PDC_scr_open(void)
     while( !PDC_get_rows( ))     /* wait for screen to be drawn and */
       ;                          /* actual size to be determined    */
 
-    EnterCriticalSection(&PDC_cs);
-
     debug_printf( "Back from PDC_get_rows\n");
     SP->lines = PDC_get_rows();
     SP->cols = PDC_get_columns();
@@ -2353,19 +2252,11 @@ int PDC_resize_screen( int nlines, int ncols)
 
         if( new_width != client_rect.right || new_height != client_rect.bottom)
         {                    /* check to make sure size actually changed */
-            DWORD thr_id = GetCurrentThreadId();
             add_resize_key = 0;
-
-            if (thr_id != winthr_id)
-                LeaveCriticalSection(&PDC_cs);
-
             SetWindowPos( PDC_hWnd, 0, 0, 0,
                    new_width + (rect.right - rect.left) - client_rect.right,
                    new_height + (rect.bottom - rect.top) - client_rect.bottom,
                   SWP_NOMOVE | SWP_NOZORDER | SWP_SHOWWINDOW);
-
-            if (thr_id != winthr_id)
-                EnterCriticalSection(&PDC_cs);
         }
     }
     return OK;

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -1002,8 +1002,6 @@ static void adjust_font_size( const int font_size_change)
     if( IsZoomed( PDC_hWnd))
     {
         RECT client_rect;
-        HDC hdc;
-
         GetClientRect( PDC_hWnd, &client_rect);
         PDC_n_rows = client_rect.bottom / PDC_cyChar;
         PDC_n_cols = client_rect.right / PDC_cxChar;
@@ -1011,10 +1009,8 @@ static void adjust_font_size( const int font_size_change)
         PDC_resize_screen( PDC_n_rows, PDC_n_cols);
         add_key_to_queue( KEY_RESIZE);
         SP->resized = TRUE;
-        hdc = GetDC (PDC_hWnd) ;
         GetClientRect( PDC_hWnd, &client_rect);
-        InvalidateRect(PDC_hWnd, &client_rect, TRUE);
-        ReleaseDC( PDC_hWnd, hdc) ;
+        InvalidateRect(PDC_hWnd, &client_rect, FALSE);
     }
     else
     {
@@ -1273,37 +1269,92 @@ static void HandleSize( const WPARAM wParam, const LPARAM lParam)
     prev_wParam = wParam;
 }
 
+/* to prevent flicker during repaint, we'll draw everything to a
+dynamically allocated backing buffer, then blit it back to the
+window's device context in one go. */
+struct BACK_BUFFER {
+    HBITMAP memory_bitmap;
+    HDC memory_dc, window_dc;
+    HANDLE original_object;
+    RECT rect;
+    bool is_rect_valid;
+} backBuffer;
+
+static void PrepareBackBuffer(HDC hdc, RECT rect)
+{
+    memset(&backBuffer, 0, sizeof(backBuffer));
+    int width = rect.right - rect.left;
+    int height = rect.bottom - rect.top;
+    backBuffer.rect = rect;
+    backBuffer.window_dc = hdc;
+    backBuffer.memory_dc = CreateCompatibleDC(hdc);
+    backBuffer.memory_bitmap = CreateCompatibleBitmap(hdc, width, height);
+    backBuffer.original_object =
+        SelectObject(backBuffer.memory_dc, backBuffer.memory_bitmap);
+    backBuffer.is_rect_valid = width > 0 && height > 0;
+}
+
+static void BlitBackBuffer()
+{
+    if (backBuffer.is_rect_valid)
+    {
+        const RECT* r = &backBuffer.rect;
+        int width = r->right - r->left;
+        int height = r->bottom - r->top;
+        BitBlt(
+            backBuffer.window_dc,
+            r->left, r->top,
+            width, height,
+            backBuffer.memory_dc,
+            0, 0,
+            SRCCOPY);
+    }
+    SelectObject(backBuffer.memory_dc, backBuffer.original_object);
+    DeleteObject(backBuffer.memory_bitmap);
+    DeleteObject(backBuffer.memory_dc);
+    memset(&backBuffer, 0, sizeof(backBuffer));
+}
+
 static void HandlePaint( HWND hwnd )
 {
     PAINTSTRUCT ps;
-    HDC hdc;
+    HDC windowDC, memoryDC;
+    RECT clientRect;
 
 /*  printf( "In HandlePaint: %ld %ld, %ld %ld\n",
                rect.left, rect.top, rect.right, rect.bottom); */
 
-    hdc = BeginPaint( hwnd, &ps);
-    RECT rect = ps.rcPaint;
+    windowDC = BeginPaint( hwnd, &ps);
+    GetClientRect(hwnd, &clientRect);
 
-    /* paint the background black. */
-    const HBRUSH hOldBrush =
-        SelectObject(hdc, GetStockObject(BLACK_BRUSH));
-    Rectangle(hdc, rect.left, rect.top, rect.right, rect.bottom);
-    SelectObject(hdc, hOldBrush);
-
-    if( curscr && curscr->_y)
+    PrepareBackBuffer(windowDC, clientRect);
+    memoryDC = backBuffer.memory_dc;
     {
-        int i, x1, n_chars;
+        /* paint the background black. */
+        const HBRUSH hOldBrush =
+            SelectObject(memoryDC, GetStockObject(BLACK_BRUSH));
+        Rectangle(memoryDC,
+            clientRect.left, clientRect.top,
+            clientRect.right, clientRect.bottom);
+        SelectObject(memoryDC, hOldBrush);
 
-        x1 = rect.left / PDC_cxChar;
-        n_chars = rect.right / PDC_cxChar - x1 + 1;
-        if( n_chars > SP->cols - x1)
-            n_chars = SP->cols - x1;
-        if( n_chars > 0)
-        for( i = rect.top / PDC_cyChar; i <= rect.bottom / PDC_cyChar; i++)
-             if( i < SP->lines && curscr->_y[i])
-                 PDC_transform_line_given_hdc( hdc, i, x1,
-                                               n_chars, curscr->_y[i] + x1);
+        /* paint all the rows */
+        if (curscr && curscr->_y)
+        {
+            int i, x1, n_chars;
+
+            x1 = clientRect.left / PDC_cxChar;
+            n_chars = clientRect.right / PDC_cxChar - x1 + 1;
+            if (n_chars > SP->cols - x1)
+                n_chars = SP->cols - x1;
+            if (n_chars > 0)
+                for (i = clientRect.top / PDC_cyChar; i <= clientRect.bottom / PDC_cyChar; i++)
+                    if (i < SP->lines && curscr->_y[i])
+                        PDC_transform_line_given_hdc(memoryDC, i, x1,
+                            n_chars, curscr->_y[i] + x1);
+        }
     }
+    BlitBackBuffer();
     EndPaint( hwnd, &ps );
 }
 
@@ -1816,7 +1867,7 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
         return 0 ;
 
     case WM_ERASEBKGND:      /* no need to erase background;  it'll */
-        return( 0);         /* all get painted over anyway */
+        return 1;         /* all get painted over anyway */
 
       /* The WM_PAINT routine is sort of "borrowed" from doupdate( ) from */
       /* refresh.c.  I'm not entirely sure that this is what ought to be  */
@@ -2023,14 +2074,14 @@ INLINE int set_up_window( void)
     {
         ATOM rval;
 
-        wndclass.style         = CS_VREDRAW ;
+        wndclass.style         = CS_VREDRAW | CS_HREDRAW;
         wndclass.lpfnWndProc   = WndProc ;
         wndclass.cbClsExtra    = 0 ;
         wndclass.cbWndExtra    = 0 ;
         wndclass.hInstance     = hInstance ;
         wndclass.hIcon         = icon;
         wndclass.hCursor       = LoadCursor (NULL, IDC_ARROW) ;
-        wndclass.hbrBackground = (HBRUSH) GetStockObject (WHITE_BRUSH) ;
+        wndclass.hbrBackground = (HBRUSH) GetStockObject (BLACK_BRUSH) ;
         wndclass.lpszMenuName  = NULL ;
         wndclass.lpszClassName = AppName ;
 

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -2051,7 +2051,8 @@ INLINE int set_up_window( void)
     HANDLE hInstance = GetModuleHandle( NULL);
     int n_default_columns = 80;
     int n_default_rows = 25;
-    int xsize, ysize, window_style;
+    int xsize, ysize;
+    DWORD window_style, window_ex_style;
     int xloc = CW_USEDEFAULT;
     int yloc = CW_USEDEFAULT;
     TCHAR WindowTitle[MAX_PATH];
@@ -2122,7 +2123,7 @@ INLINE int set_up_window( void)
     else  /* fixed-size window:  looks "normal",  but w/o a maximize box */
         window_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
 
-    DWORD window_ex_style = WS_EX_CLIENTEDGE;
+    window_ex_style = WS_EX_CLIENTEDGE;
 
     if( n_default_columns == -1)
         xsize = ysize = CW_USEDEFAULT;

--- a/wingui/pdcsetsc.c
+++ b/wingui/pdcsetsc.c
@@ -60,20 +60,17 @@ int PDC_curs_set(int visibility)
 void PDC_set_title(const char *title)
 {
     extern HWND PDC_hWnd;
-    extern CRITICAL_SECTION PDC_cs;
 #ifdef PDC_WIDE
     wchar_t wtitle[512];
 #endif
     PDC_LOG(("PDC_set_title() - called:<%s>\n", title));
 
-    LeaveCriticalSection(&PDC_cs);
 #ifdef PDC_WIDE
     PDC_mbstowcs(wtitle, title, 511);
     SetWindowTextW( PDC_hWnd, wtitle);
 #else
     SetWindowTextA( PDC_hWnd, title);
 #endif
-    EnterCriticalSection(&PDC_cs);
 }
 
         /* If SP->termattrs & A_BLINK is on, then text with the A_BLINK  */

--- a/wingui/pdcutil.c
+++ b/wingui/pdcutil.c
@@ -6,8 +6,6 @@
 #include <process.h>
 #endif
 
-extern CRITICAL_SECTION PDC_cs;
-
 static volatile int _beep_count = 0;
 
 static void beep_thread(LPVOID lpParameter)
@@ -32,14 +30,30 @@ void PDC_beep(void)
 void PDC_napms(int ms)     /* 'ms' = milli,  _not_ microseconds! */
 {
     /* RR: keep GUI window responsive while PDCurses sleeps */
+    MSG msg;
+    DWORD curr_ms = GetTickCount( );
+    const DWORD milliseconds_sleep_limit = ms + curr_ms;
+    extern bool PDC_bDone;
 
     PDC_LOG(("PDC_napms() - called: ms=%d\n", ms));
 
-    if( ms)
+    /* Pump all pending messages from WIN32 to the window handler */
+    while( !PDC_bDone && curr_ms < milliseconds_sleep_limit )
     {
-        LeaveCriticalSection(&PDC_cs);
-        Sleep(ms);
-        EnterCriticalSection(&PDC_cs);
+        const DWORD max_sleep_ms = 50;      /* check msgs 20 times/second */
+        DWORD sleep_millisecs;
+
+        while( PeekMessage(&msg, NULL, 0, 0, PM_REMOVE) )
+        {
+           TranslateMessage(&msg);
+           DispatchMessage(&msg);
+        }
+        curr_ms = GetTickCount( );
+        sleep_millisecs = milliseconds_sleep_limit - curr_ms;
+        if( sleep_millisecs > max_sleep_ms)
+            sleep_millisecs = max_sleep_ms;
+        Sleep( sleep_millisecs);
+        curr_ms += sleep_millisecs;
     }
 }
 


### PR DESCRIPTION
# Overview

Some time ago a change was merged into `PDCursesMod` to offload Window message handling to a background thread to make resizing happen more fluidly: https://github.com/Bill-Gray/PDCursesMod/commit/dd59e4cee70af08b86c111deba29cb7d2f795bb9

Unfortunately, this caused some issues with my apps. Specifically, I augment existing `PDCursesMod` functionality to do things like change the app icon and support minimizing to the notification tray. To do this, I get a reference to the main Window Handle (`HWND`), and call various Win32 API methods against it. Unfortunately, I am making these calls from the main app thread, not the thread running the message pump, so it leads to weird/undefined behavior that usually manifests as the app freezing at random times during operation, and very often during startup and shutdown when I'm making these API calls.

# Why does `PDCursesMod` use a non-main Window thread?

This had me scratching my head for a while, but after a couple hours of debugging I figured it out. When `getch()` or one of its variants are called, pending key events are returned to the caller, but only after all pending Windows messages have been processed by the internal message pump.

The main message pump in `PDCursesMod` (and most Win32) apps looks like this, in `PDC_napms`:

```c++
while( PeekMessage(&msg, NULL, 0, 0, PM_REMOVE) )
{
    TranslateMessage(&msg);
    DispatchMessage(&msg);
}
```

Basically: it runs a tight loop until the message queue is completely drained.

However, when a resize event starts (i.e the user clicks the resize handle), the message pump remains active, as the Windows runtime is using it to monitor and process mouse moves, converting them to `WM_SIZE` and `WM_SIZING` messages. **That means that the curses KEY_RESIZE event is not returned to the caller until the message pump is drained, and all sizing has finished**. So, while the native window itself updates and changes size, the client app does not have an opportunity to update its curses `WINDOW` and/or `PANEL` instances until it's too late (i.e. sizing has finished).

Offloading the message processing to a separate thread, along with some careful synchronization via `CRITICAL_SECTION` addresses this immediate issue, but it introduces other problems as described above (i.e. whenever the user needs to do something with the main `HWND` directly).

# A potential solution

On UNIX platforms we can handle the `SIGWINCH` signal to be notified when the controlling terminal changes size, then update our `WINDOW` and `PANEL` instances accordingly. Unfortunately we don't have this luxury on Windows.

However, we could add a `WinGui` specific callback to the `PDC` API that fires during `WM_SIZE`, whenever the Window has changed dimensions. The calling app could then use this the same way it handles `SIGWINCH` on UNIX platforms to update layout, and then we're good to go.

Clearly the downside is this introduces a non-standard, bespoke API for only `WinGui`, but it would do away with the goofy `CRITICAL_SECTION` management stuff, and also generally make things more stable.

# Code changes

Unfortunately, I realize that the introduction of a custom API just for `WinGui` is undesirable and will likely result in this change not being merged. However, I wanted to share my findings and a sample implementation, as it may be useful for coming up with a more robust solution.

This proof-of-concept implementation spans 4 commits; it's probably easiest to view this commit-by-commit with the following commentary:

1. https://github.com/clangen/PDCurses/commit/dd59e4cee70af08b86c111deba29cb7d2f795bb9: reverted the original commit that introduced multi-threading.
2. https://github.com/clangen/PDCurses/pull/3/commits/451b2137f27c36fb10bac58f5c8abce232ba938e: noticed some weird background painting issues while resizing, so I simplified the code to ensure it always just paints a black background before anything else.
3. https://github.com/clangen/PDCurses/pull/3/commits/26d39f49eff64c17efb317a7e4d170ed07e1ec07: added the bespoke API described above that will fire a callback whenever the Window size changes. Also fixed a bit of mouse handling code in the WndProc, as it had been changed upstream (for the better)
4. https://github.com/clangen/PDCurses/pull/3/commits/2be5a265342a0872a6af09b93e9151e6b1b0caf4: added double buffering to the `WM_PAINT` handling to ensure there is no/minimal flicker when aggressively resizing. Windows isn't very good about batching draw commands to an on-screen DC, so we accumulate all updates to an offscreen buffer, then blit it back to the screen all at once. (This is an old Win32 trick to deal with this sort of issue).

# Demo

Here's what it looks like, said and done:

https://user-images.githubusercontent.com/2031666/180672281-4e950dc7-caba-470c-9396-5caee248e2d8.mov
