### PR TITLE
minor performance for getch

### DIFF
--- a/pdcurses/getch.c
+++ b/pdcurses/getch.c
@@ -539,27 +539,37 @@ int wgetch(WINDOW *win)
         /* if there is, fetch it */
 
         key = PDC_get_key();
+        
+        /* loop back if we did not get a key yet */
 
-        /* copy or paste? */
-
-#ifndef _WIN32
-        if (SP->key_modifiers & PDC_KEY_MODIFIER_SHIFT)
-#endif
-        {
-            if (PDC_function_key[FUNCTION_KEY_COPY] == key)
-            {
-                _copy();
-                continue;
-            }
-            else if (PDC_function_key[FUNCTION_KEY_PASTE] == key)
-                key = _paste();
-        }
+        if (key == -1)
+            continue;
 
         /* filter mouse events; translate mouse clicks in the slk
-           area to function keys */
+           area to function keys (especially copy + pase) */
 
         if( key == KEY_MOUSE)
+        {
             key = _mouse_key();
+        }
+        else
+        {
+
+            /* copy or paste? */
+#ifndef _WIN32
+            if (SP->key_modifiers & PDC_KEY_MODIFIER_SHIFT)
+#endif
+            {
+                if (PDC_function_key[FUNCTION_KEY_COPY] == key)
+                {
+                    _copy();
+                    continue;
+                }
+                else if (PDC_function_key[FUNCTION_KEY_PASTE] == key)
+                    key = _paste();
+            }
+            
+        }
 
         /* filter special keys if not in keypad mode */
 


### PR DESCRIPTION
... just a suggestion (and warning: I did not even tried to compile that...)

* early loop back if there is no key ready - at least during debugging this was quite often the case [which is the main reason for this suggestion]
* only check for copy/paste if we don't have a mouse event [occurred to me during adjustment when reading the code]

I was not 100% sure if the copy/paste keys may apply to the "filter special keys if not in keypad mode", if they aren't then this also does not need to be done when we have a mouse event and then also not in the copy paste code.