### PR TITLE
Fix wgetnstr with PDC_WIDE

### DIFF
--- a/pdcurses/getstr.c
+++ b/pdcurses/getstr.c
@@ -74,12 +74,17 @@ int wgetnstr(WINDOW *win, char *str, int n)
 {
 #ifdef PDC_WIDE
     wchar_t wstr[MAXLINE + 1];
+    wint_t wintstr[MAXLINE + 1];
+    int i;
 
     if (n < 0 || n > MAXLINE)
         n = MAXLINE;
 
-    if (wgetn_wstr(win, (wint_t *)wstr, n) == ERR)
+    if (wgetn_wstr(win, wintstr, n) == ERR)
         return ERR;
+    for (i = 0; i < n; ++i) {
+        wstr[i] = (wchar_t)wintstr[i];
+    }
 
     return (int)PDC_wcstombs(str, wstr, n);
 #else


### PR DESCRIPTION
Casting an array of wchar_t to wint_t * works as intended only if wchar_t and wint_t have the same size. If they don't, wgetnstr will not work. Cast the elements to wchar_t instead.