### PR TITLE
add terminfo

### DIFF
--- a/common/libobjs.mif
+++ b/common/libobjs.mif
@@ -1,5 +1,5 @@
 # Common elements for most of the DOS, OS/2 and Windows
-# makefiles (not Watcom)
+# makefiles (not Watcom) along with the portable GCC one
 
 PDCURSES_CURSES_H	= $(PDCURSES_SRCDIR)/curses.h
 PDCURSES_CURSPRIV_H	= $(PDCURSES_SRCDIR)/curspriv.h
@@ -15,7 +15,8 @@ getch.$(O) getstr.$(O) getyx.$(O) inch.$(O) inchstr.$(O) \
 initscr.$(O) inopts.$(O) insch.$(O) insstr.$(O) instr.$(O) kernel.$(O) \
 keyname.$(O) mouse.$(O) move.$(O) outopts.$(O) overlay.$(O) pad.$(O) \
 panel.$(O) printw.$(O) refresh.$(O) scanw.$(O) scr_dump.$(O) scroll.$(O) \
-slk.$(O) termattr.$(O) touch.$(O) util.$(O) window.$(O) debug.$(O)
+slk.$(O) termattr.$(O) touch.$(O) util.$(O) window.$(O) debug.$(O) \
+terminfo.$(O)
 
 PDCOBJS = pdcclip.$(O) pdcdisp.$(O) pdcgetsc.$(O) pdckbd.$(O) pdcscrn.$(O) \
 pdcsetsc.$(O) pdcutil.$(O)


### PR DESCRIPTION
follow-up to d5d2d8a857dba7732e61c5317b493219a1b0f26b which only partially reverted 22c4d82f8cd370d7af7ee805de4b4adc3e95ce1e; superseded by ab1c0072733f3147811ffa1b5152449ff0961b67

this is not yet complete, more checks are needed for:

* [X] Makefiles: also install term.h?
* [X] Makefiles for several ports
* [ ] framebuffer/DRM port, which didn't exist when the terminfo functions were removed or added
* [ ] demos: add at least linking, ideally some using of those functions
* [ ] cmake handling
* [ ] docs