### PR TITLE
Enable user trapping of windows close on SDL1 and SDL2

### DIFF
--- a/sdl1/pdckbd.c
+++ b/sdl1/pdckbd.c
@@ -320,7 +320,11 @@ int PDC_get_key(void)
     switch (event.type)
     {
     case SDL_QUIT:
-        exit(1);
+        if( !PDC_get_function_key( FUNCTION_KEY_SHUT_DOWN))
+        {
+            exit(1);
+        }
+        return PDC_get_function_key( FUNCTION_KEY_SHUT_DOWN);
     case SDL_VIDEORESIZE:
         if (pdc_own_screen &&
            (event.resize.h / pdc_fheight != LINES ||

--- a/sdl2/pdckbd.c
+++ b/sdl2/pdckbd.c
@@ -438,7 +438,11 @@ int PDC_get_key(void)
     switch (event.type)
     {
     case SDL_QUIT:
-        exit(1);
+        if( !PDC_get_function_key( FUNCTION_KEY_SHUT_DOWN))
+        {
+            exit(1);
+        }
+        return PDC_get_function_key( FUNCTION_KEY_SHUT_DOWN);
     case SDL_WINDOWEVENT:
         if (SDL_WINDOWEVENT_SIZE_CHANGED == event.window.event)
         {


### PR DESCRIPTION
Wingui and X11 allow the user to call PDC_set_function_key() for FUNCTION_KEY_SHUT_DOWN so the user can handle the window close event within their program. This patch enables that capability for SDL1 and SDL2 ports