### PR TITLE
Ensure `WM_CHAR` functions properly when `_UNICODE` is defined.

### DIFF
--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -1919,7 +1919,28 @@ static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
             exit( 0);
         if( wParam != 9 || !(GetKeyState( VK_SHIFT) & 0x8000))
             if( !key_already_handled)
-               add_key_to_queue( (int)wParam );
+#if _UNICODE
+                /* if we are building against the unicode runtime, key messages
+                received by WM_CHAR will be UTF16 encoded; convert it to a
+                sequence UTF8 bytes and inject them one at a time.
+                see: https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-char */
+                wchar_t utf16[3]; /* may be a surrogate pair */
+                utf16[0] = LOWORD(wParam);
+                utf16[1] = HIWORD(wParam);
+                utf16[2] = 0;
+                unsigned char utf8[4 + 4 + 1];
+                int size = WideCharToMultiByte(CP_UTF8, 0, utf16, -1, 0, 0, 0, 0);
+                if (size > 0 && sizeof(utf8)) {
+                    utf8[0] = 0;
+                    WideCharToMultiByte(CP_UTF8, 0, utf16, -1, utf8, size, 0, 0);
+                    for (int i = 0; i < size - 1; i++) {
+                        add_key_to_queue((int) utf8[i]);
+                    }
+                }
+#else
+                add_key_to_queue((int)wParam);
+#endif
+            }
         key_already_handled = FALSE;
         return 0;
 


### PR DESCRIPTION
Note: I think that this patch in its current form may not be something you'd want to merge; it may not even be something you want to merge at all, but I wanted to bring it up...

My app that uses `PDCursesMod` is compiled with the `Use Unicode Character Set` option with MSVC++, which will ensure all `Win32` API calls use the wide-character variants, all of which use UTF16 encoded characters and strings regardless of the user's selected locale.

That means that when `_UNICODE` is defined the character sent to the `WM_CHAR` message is UTF16 encoded -- and  `PDCursesMod` adds it to key queue directly via `add_key_to_queue((int) wParam);` My app defines `PDC_FORCE_UTF8`, so I was assuming that internally this character would be converted to a sequence of UTF8 bytes to be received by `getch()` calls.

However, this was not the case, and parsing some non-ascii characters was problematic. To work around this, I added a patch that converts the UTF16 character received by `WM_CHAR` into a sequence of UTF8 bytes, and adds them to the key queue one at a time.