### PR TITLE
Provides full unicode output for wincon

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1,3 +1,34 @@
+PDCursesMod as of 2023 March 04
+=================================
+
+Minor new features
+------------------
+
+- All the environments: support for full unicode input including codepoints
+  above 0xFFFF, for instance emojis. [7e28f97](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/7e28f97cf158c33bf4944beab19d9e09a6ef3277)
+
+- WINCON: supports full unicode output including codepoints
+  above 0xFFFF, for instance emojis. [6c501d6](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/6c501d627b34447e987eaec1593bc560d530fed7)
+
+- WINCON: Support for cross compilation for Windows on Arm. [a185262](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/a18526233c71353f5040a310efcfb2d44fe1b4fa)
+
+Bug fixes
+---------
+
+- WINCON: Key modifiers were incorrectly cleared without a key event.
+  [e828471](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/e828471f04140535f6267b03719f52fb0d58064f)
+
+- WINCON: Transparent background was not working in terminals supporting the 
+  feature when using ANSI mode. [6e0d482](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/6e0d48229ddc169e90e749b26dc2f8da8e981940)
+
+- WINCON: Makefile was not compatible with LLVM-MinGW as prefix was missing
+  in AR and STRIP utilities. [bf201ec](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/bf201ec2f7c826469a743d116855d0a3f0c9bebe)
+
+- WINCON: Makefile was clearing CFLAGS variable. Now it can accept custom
+  flags. [bf201ec](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/bf201ec2f7c826469a743d116855d0a3f0c9bebe)
+
+See the git log for more details.
+
 PDCursesMod as of 2023 January 07
 =================================
 

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -10,8 +10,6 @@ Minor new features
 - WINCON: supports full unicode output including codepoints
   above 0xFFFF, for instance emojis. [6c501d6](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/6c501d627b34447e987eaec1593bc560d530fed7)
 
-- WINCON: Support for cross compilation for Windows on Arm. [a185262](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/a18526233c71353f5040a310efcfb2d44fe1b4fa)
-
 Bug fixes
 ---------
 
@@ -21,16 +19,9 @@ Bug fixes
 - WINCON: Transparent background was not working in terminals supporting the 
   feature when using ANSI mode. [6e0d482](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/6e0d48229ddc169e90e749b26dc2f8da8e981940)
 
-- WINCON: Makefile was not compatible with LLVM-MinGW as prefix was missing
-  in AR and STRIP utilities. [bf201ec](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/bf201ec2f7c826469a743d116855d0a3f0c9bebe)
-
-- WINCON: Makefile was clearing CFLAGS variable. Now it can accept custom
-  flags. [bf201ec](https://github.com/Bill-Gray/PDCursesMod/pull/273/commits/bf201ec2f7c826469a743d116855d0a3f0c9bebe)
-
 See the git log for more details.
-
-PDCursesMod as of 2023 January 07
-=================================
+PDCursesMod as of 2023 March 04
+===============================
 
 Minor new features
 ------------------
@@ -66,6 +57,9 @@ Bug fixes
 
 - WinGUI could get confused if the window was resized,  resulting in
   input being ignored.  bc340c0d20
+
+- Text selection & copying could cause memory corruption with 4 byte UTF-8
+  codepoints when WIDE=Y.  bff53ab114
 
 See the git log for more details.
 

--- a/wincon/Makefile
+++ b/wincon/Makefile
@@ -66,10 +66,10 @@ PDCURSES_WIN_H	= $(osdir)/pdcwin.h
 
 CC	= $(PREFIX)gcc
 
-AR	= ar
-STRIP	= strip
+AR	= $(PREFIX)ar
+STRIP	= $(PREFIX)strip
 
-CFLAGS  = -Wall -Wextra -pedantic
+CFLAGS  += -Wall -Wextra -pedantic
 ifeq ($(DEBUG),Y)
 	CFLAGS  += -g -DPDCDEBUG
 	LDFLAGS = -g

--- a/wincon/Makefile
+++ b/wincon/Makefile
@@ -55,12 +55,12 @@ endif
 # Only decision is:  are we doing a 64-bit compile (_w64 defined)?
 
 ifndef ON_WINDOWS
-    PREFIX  = i686-w64-mingw32-
+	PREFIX  = i686-w64-mingw32-
 	ifdef _w64
-	   PREFIX  = x86_64-w64-mingw32-
+		PREFIX  = x86_64-w64-mingw32-
 	endif
 	ifdef _a64
-	   PREFIX  = aarch64-w64-mingw32-
+		PREFIX  = aarch64-w64-mingw32-
 	endif
 endif
 

--- a/wincon/Makefile
+++ b/wincon/Makefile
@@ -55,10 +55,12 @@ endif
 # Only decision is:  are we doing a 64-bit compile (_w64 defined)?
 
 ifndef ON_WINDOWS
+    PREFIX  = i686-w64-mingw32-
 	ifdef _w64
 	   PREFIX  = x86_64-w64-mingw32-
-	else
-	   PREFIX  = i686-w64-mingw32-
+	endif
+	ifdef _a64
+	   PREFIX  = aarch64-w64-mingw32-
 	endif
 endif
 

--- a/wincon/Makefile
+++ b/wincon/Makefile
@@ -55,12 +55,10 @@ endif
 # Only decision is:  are we doing a 64-bit compile (_w64 defined)?
 
 ifndef ON_WINDOWS
-	PREFIX  = i686-w64-mingw32-
 	ifdef _w64
-		PREFIX  = x86_64-w64-mingw32-
-	endif
-	ifdef _a64
-		PREFIX  = aarch64-w64-mingw32-
+	   PREFIX  = x86_64-w64-mingw32-
+	else
+	   PREFIX  = i686-w64-mingw32-
 	endif
 endif
 
@@ -68,10 +66,10 @@ PDCURSES_WIN_H	= $(osdir)/pdcwin.h
 
 CC	= $(PREFIX)gcc
 
-AR	= $(PREFIX)ar
-STRIP	= $(PREFIX)strip
+AR	= ar
+STRIP	= strip
 
-CFLAGS  += -Wall -Wextra -pedantic
+CFLAGS  = -Wall -Wextra -pedantic
 ifeq ($(DEBUG),Y)
 	CFLAGS  += -g -DPDCDEBUG
 	LDFLAGS = -g

--- a/wincon/pdcdisp.c
+++ b/wincon/pdcdisp.c
@@ -169,8 +169,14 @@ static void _show_run_of_ansi_characters( const attr_t attr,
             ch = ' ';
 
 #ifdef PDC_WIDE
-        if( (ch & A_CHARTEXT) != DUMMY_CHAR_NEXT_TO_FULLWIDTH)
-            buffer[n_out++] = (WCHAR)( ch & A_CHARTEXT);
+        chtype uc = ch & A_CHARTEXT;  //o//
+        if( uc != DUMMY_CHAR_NEXT_TO_FULLWIDTH){
+            if (uc & 0xFF0000){
+                buffer[n_out++] = (WCHAR)((uc - 0x10000) >> 10 | 0xD800); /* first UTF-16 unit */
+                buffer[n_out++] = (WCHAR)(uc & 0x3FF) | 0xDC00;         /* second UTF-16 unit */
+            }else   
+               buffer[n_out++] = (WCHAR)( ch & A_CHARTEXT);
+        }
 #else
         buffer[n_out++] = (char)( ch & A_CHARTEXT);
 #endif

--- a/wincon/pdcdisp.c
+++ b/wincon/pdcdisp.c
@@ -195,7 +195,7 @@ static void _show_run_of_nonansi_characters( const attr_t attr,
                            int fore, int back, const bool blink,
                            const int lineno, const int x, const chtype *srcp, const int len)
 {
-    CHAR_INFO buffer[MAX_PACKET_SIZE];
+    CHAR_INFO buffer[MAX_PACKET_SIZE*2];
     COORD bufSize, bufPos;
     SMALL_RECT sr;
     WORD mapped_attr;

--- a/wincon/pdcdisp.c
+++ b/wincon/pdcdisp.c
@@ -152,7 +152,7 @@ static void _show_run_of_ansi_characters( const attr_t attr,
                            const int lineno, const int x, const chtype *srcp, const int len)
 {
 #ifdef PDC_WIDE
-    WCHAR buffer[MAX_PACKET_SIZE];
+    WCHAR buffer[MAX_PACKET_SIZE*2];
 #else
     char buffer[MAX_PACKET_SIZE];
 #endif
@@ -169,9 +169,9 @@ static void _show_run_of_ansi_characters( const attr_t attr,
             ch = ' ';
 
 #ifdef PDC_WIDE
-        chtype uc = ch & A_CHARTEXT;  //o//
-        if( uc != DUMMY_CHAR_NEXT_TO_FULLWIDTH){
-            if (uc & 0xFF0000){
+        chtype uc = ch & A_CHARTEXT;
+        if( uc < 0x110000){
+            if (uc & 0x1F0000){
                 buffer[n_out++] = (WCHAR)((uc - 0x10000) >> 10 | 0xD800); /* first UTF-16 unit */
                 buffer[n_out++] = (WCHAR)(uc & 0x3FF) | 0xDC00;         /* second UTF-16 unit */
             }else   
@@ -228,10 +228,18 @@ static void _show_run_of_nonansi_characters( const attr_t attr,
 
         buffer[n_out].Attributes = mapped_attr;
 #ifdef PDC_WIDE
-            if( (ch & A_CHARTEXT) != DUMMY_CHAR_NEXT_TO_FULLWIDTH)
+        chtype uc = ch & A_CHARTEXT;
+        if( uc < 0x110000){
+            if (uc & 0x1F0000){
+                buffer[n_out++].Char.UnicodeChar = (WCHAR)((uc - 0x10000) >> 10 | 0xD800); /* first UTF-16 unit */
+                buffer[n_out].Attributes = mapped_attr;
+                buffer[n_out++].Char.UnicodeChar = (WCHAR)(uc & 0x3FF) | 0xDC00;   /* second UTF-16 unit */
+            }else   
+                buffer[n_out++].Char.UnicodeChar = (WCHAR)uc;
+        }
+#else
+        buffer[n_out++].Char.UnicodeChar = (WCHAR)( ch & A_CHARTEXT);
 #endif
-           buffer[n_out++].Char.UnicodeChar = (WCHAR)( ch & A_CHARTEXT);
-    }
 
     bufPos.X = bufPos.Y = 0;
     bufSize.X = (SHORT)n_out;

--- a/wincon/pdckbd.c
+++ b/wincon/pdckbd.c
@@ -729,8 +729,6 @@ static int _process_mouse_event(void)
 
 int PDC_get_key(void)
 {
-    SP->key_modifiers = 0L;
-
     if (!key_count)
     {
         DWORD count;
@@ -752,6 +750,7 @@ int PDC_get_key(void)
         switch (save_ip.EventType)
         {
         case KEY_EVENT:
+            SP->key_modifiers = 0L;
             return _process_key_event();
 
         case MOUSE_EVENT:

--- a/wincon/pdcscrn.c
+++ b/wincon/pdcscrn.c
@@ -415,11 +415,7 @@ int PDC_scr_open(void)
     pdc_wt = !!getenv("WT_SESSION");
     str = pdc_wt ? NULL : getenv("ConEmuANSI");
     pdc_conemu = !!str;
-    pdc_ansi =
-#ifdef PDC_WIDE
-        pdc_wt ? TRUE :
-#endif
-        pdc_conemu ? !strcmp(str, "ON") : FALSE;
+    pdc_ansi = !pdc_wt && pdc_conemu && !strcmp(str, "ON");
 
     GetConsoleScreenBufferInfo(pdc_con_out, &csbi);
     GetConsoleScreenBufferInfo(pdc_con_out, &orig_scr);

--- a/wincon/pdcscrn.c
+++ b/wincon/pdcscrn.c
@@ -415,7 +415,12 @@ int PDC_scr_open(void)
     pdc_wt = !!getenv("WT_SESSION");
     str = pdc_wt ? NULL : getenv("ConEmuANSI");
     pdc_conemu = !!str;
-    pdc_ansi = !pdc_wt && pdc_conemu && !strcmp(str, "ON");
+//    pdc_ansi = !pdc_wt && pdc_conemu && !strcmp(str, "ON"); //o//
+    pdc_ansi =
+#ifdef PDC_WIDE
+        pdc_wt ? TRUE :
+#endif
+        pdc_conemu ? !strcmp(str, "ON") : FALSE;
 
     GetConsoleScreenBufferInfo(pdc_con_out, &csbi);
     GetConsoleScreenBufferInfo(pdc_con_out, &orig_scr);


### PR DESCRIPTION
Windows API requires a sequence of UTF-16 encoded wchars. This commit identifies whether a Unicode codepoint is above 0xFFFF and, in that case, encodes them into UTF-16 before passing it to windows API.