### PR TITLE
Switch to windows-2022 runner

### DIFF
--- a/.github/workflows/github_actions_build.yml
+++ b/.github/workflows/github_actions_build.yml
@@ -26,13 +26,13 @@ jobs:
          make CLANG=Y demos
 
   buildWindows:
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@master
     - name: make
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
         cd wingui
         nmake UTF8=Y DLL=Y -f Makefile.vc demos
         cd ..\wincon


### PR DESCRIPTION
Tested and working in
https://github.com/rasa/PDCursesMod/actions/runs/4037625479/jobs/6941054143
via
https://github.com/rasa/PDCursesMod/blob/master/.github/workflows/windows-latest.yml
per
https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#visual-studio-enterprise-2022