### PR TITLE
Fix text selection memory corruption with long codepoints

### DIFF
--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1,5 +1,5 @@
-PDCursesMod as of 2023 January 07
-=================================
+PDCursesMod as of 2023 March 04
+===============================
 
 Minor new features
 ------------------
@@ -35,6 +35,9 @@ Bug fixes
 
 - WinGUI could get confused if the window was resized,  resulting in
   input being ignored.  bc340c0d20
+
+- Text selection & copying could cause memory corruption with 4 byte UTF-8
+  codepoints when WIDE=Y.  bff53ab114
 
 See the git log for more details.
 

--- a/pdcurses/getch.c
+++ b/pdcurses/getch.c
@@ -228,7 +228,7 @@ static void _copy(void)
 
 #ifdef PDC_WIDE
     wtmp = (wchar_t *)malloc((len + 1) * sizeof(wchar_t));
-    len *= 3;
+    len *= 4;
 #endif
     tmp = (char *)malloc(len + 1);
 


### PR DESCRIPTION
With certain Unicode code points, the maximum length of a multi-byte string is 4 times the `wchar_t` string length, so let's multiply by 4 instead of 3. The way to trigger the bug was to:

1. Fill the screen with code points that expand to 4 bytes in UTF-8 (e.g. "🭂")
2. Attempt to repeatedly select large blocks of text (e.g. in the SDL2 port)
3. Observe as `double free or corruption (!prev)` happens!