### PR TITLE
[WINCON/WINGUI/SDL2/VT] Added support for cross compilation for Windows on Arm: Enabled custom CFLAGS. Fix missing prefixes for AR and STRIP

### DIFF
--- a/sdl2/Makefile
+++ b/sdl2/Makefile
@@ -19,7 +19,7 @@ include $(common)/libobjs.mif
 
 PREFIX = $(shell $(CC) -dumpmachine)
 
-ifdef _w64
+ifdef _w32
 	PREFIX = i686-w64-mingw32
 	E = .exe
 endif

--- a/sdl2/Makefile
+++ b/sdl2/Makefile
@@ -5,7 +5,6 @@
 #
 # where target can be any of:
 # [all|demos|libpdcurses.a|testcurs]...
-# Requires $TTFBASE and $SDLBASE environmental variables.
 
 O = o
 
@@ -18,13 +17,19 @@ common		= $(PDCURSES_SRCDIR)/common
 
 include $(common)/libobjs.mif
 
-PREFIX=i686-w64-mingw32
-E = .exe
+PREFIX = $(shell $(CC) -dumpmachine)
+
 ifdef _w64
-	PREFIX=x86_64-w64-mingw32
+	PREFIX = i686-w64-mingw32
+	E = .exe
+endif
+ifdef _w64
+	PREFIX = x86_64-w64-mingw32
+	E = .exe
 endif
 ifdef _a64
-	PREFIX=aarch64-w64-mingw32
+	PREFIX = aarch64-w64-mingw32
+	E = .exe
 endif
 
 ifeq ($(OS),Windows_NT)

--- a/sdl2/Makefile
+++ b/sdl2/Makefile
@@ -5,6 +5,7 @@
 #
 # where target can be any of:
 # [all|demos|libpdcurses.a|testcurs]...
+# Requires $TTFBASE and $SDLBASE environmental variables.
 
 O = o
 
@@ -17,13 +18,13 @@ common		= $(PDCURSES_SRCDIR)/common
 
 include $(common)/libobjs.mif
 
+PREFIX=i686-w64-mingw32
+E = .exe
 ifdef _w64
-	PREFIX=x86_64-w64-mingw32-
-	E = .exe
+	PREFIX=x86_64-w64-mingw32
 endif
-ifdef _w32
-	PREFIX=i686-w64-mingw32-
-	E = .exe
+ifdef _a64
+	PREFIX=aarch64-w64-mingw32
 endif
 
 ifeq ($(OS),Windows_NT)
@@ -38,7 +39,7 @@ ifeq ($(OS),Windows_NT)
 	SLIBS = -L$(SDLBASE)/$(PLATFORM)/lib -lSDL2main -lSDL2
 
 	TFLAGS = -I$(TTFBASE)/$(PLATFORM)/include/SDL2
-	TLIBS =-L$(TTFBASE)/$(PLATFORM)/lib -lSDL2_ttf
+	TLIBS = -L$(TTFBASE)/$(PLATFORM)/lib -lSDL2_ttf
 
 	DEMOFLAGS = -mwindows
 else
@@ -47,10 +48,11 @@ else
 	SFLAGS = $(shell sdl2-config --cflags)
 	SLIBS = $(shell sdl2-config --libs)
 
-	TLIBS = -lSDL2_ttf
+	TFLAGS = -I$(TTFBASE)/$(PREFIX)/include/SDL2
+	TLIBS = -L$(TTFBASE)/$(PREFIX)/lib -lSDL2_ttf
 endif
 
-CC		= $(PREFIX)gcc
+CC		= $(PREFIX)-gcc
 WINDRES		= windres
 
 PDCURSES_SDL_H	= $(osdir)/pdcsdl.h
@@ -107,7 +109,7 @@ ifeq ($(DLL),Y)
 		CLEAN = *$(DLL_SUFFIX)
 	endif
 else
-	LIBEXE = $(AR)
+	LIBEXE = $(PREFIX)-$(AR)
 	LIBFLAGS = rcv
 	LIBCURSES = lib$(LIBNAME).a
 	LDFLAGS = $(LIBCURSES) $(SLIBS)
@@ -131,7 +133,7 @@ clean:
 
 demos:	$(DEMOS)
 ifneq ($(DEBUG),Y)
-	strip $(DEMOS)
+	$(PREFIX)-strip $(DEMOS)
 endif
 
 install:

--- a/vt/Makefile
+++ b/vt/Makefile
@@ -59,6 +59,11 @@ ifdef _w32
 	E = .exe
 endif
 
+ifdef _a64
+	PREFIX  = aarch64-w64-mingw32-
+	E = .exe
+endif
+
 ifeq ($(OS),Windows_NT)
 	E = .exe
 	RM = cmd /c del
@@ -99,7 +104,7 @@ BUILD		= $(CC) $(CFLAGS) -I$(PDCURSES_SRCDIR)
 
 LINK		= $(CC)
 LDFLAGS		= $(LIBCURSES)
-RANLIB		= ranlib
+RANLIB		= $(PREFIX)ranlib
 
 .PHONY: all libs clean demos
 

--- a/wincon/Makefile
+++ b/wincon/Makefile
@@ -1,7 +1,8 @@
-# GNU MAKE Makefile for PDCurses library - WIN32 MinGW GCC
+# GNU MAKE Makefile for PDCurses library - WIN32/64/ARM MinGW GCC/LLVM
 #
 # Usage: [g]make [-f path\Makefile] [DEBUG=Y] [DLL=Y] [WIDE=Y] [UTF8=Y]
 #        [INFOEX=N] [LIBNAME=(name)] [DLLNAME=(name)] [target]
+#        [_w32=Y | _w64=Y | _a64=Y ]
 #
 # where target can be any of:
 # [all|demos|pdcurses.a|testcurs.exe...]
@@ -55,10 +56,12 @@ endif
 # Only decision is:  are we doing a 64-bit compile (_w64 defined)?
 
 ifndef ON_WINDOWS
+	PREFIX  = i686-w64-mingw32-
 	ifdef _w64
-	   PREFIX  = x86_64-w64-mingw32-
-	else
-	   PREFIX  = i686-w64-mingw32-
+		PREFIX  = x86_64-w64-mingw32-
+	endif
+	ifdef _a64
+		PREFIX  = aarch64-w64-mingw32-
 	endif
 endif
 
@@ -66,10 +69,10 @@ PDCURSES_WIN_H	= $(osdir)/pdcwin.h
 
 CC	= $(PREFIX)gcc
 
-AR	= ar
-STRIP	= strip
+AR	= $(PREFIX)ar
+STRIP	= $(PREFIX)strip
 
-CFLAGS  = -Wall -Wextra -pedantic
+CFLAGS  += -Wall -Wextra -pedantic
 ifeq ($(DEBUG),Y)
 	CFLAGS  += -g -DPDCDEBUG
 	LDFLAGS = -g

--- a/wingui/Makefile
+++ b/wingui/Makefile
@@ -1,7 +1,8 @@
-# GNU MAKE Makefile for PDCurses library - WIN32 MinGW GCC WinGUI
+# GNU MAKE Makefile for PDCurses library - WIN32/64/ARM MinGW GCC/LLVM
 #
 # Usage: [g]make [-f path\Makefile] [DEBUG=Y] [DLL=Y] [WIDE=Y] [UTF8=Y]
-#        [LIBNAME=(name)] [DLLNAME=(name)] [target]
+#        [INFOEX=N] [LIBNAME=(name)] [DLLNAME=(name)] [target]
+#        [_w32=Y | _w64=Y | _a64=Y ]
 #
 # where target can be any of:
 # [all|demos|pdcurses.a|testcurs.exe...]
@@ -55,10 +56,12 @@ endif
 # Only decision is:  are we doing a 64-bit compile (_w64 defined)?
 
 ifndef ON_WINDOWS
+	PREFIX  = i686-w64-mingw32-
 	ifdef _w64
-	   PREFIX  = x86_64-w64-mingw32-
-	else
-	   PREFIX  = i686-w64-mingw32-
+		PREFIX  = x86_64-w64-mingw32-
+	endif
+	ifdef _a64
+		PREFIX  = aarch64-w64-mingw32-
 	endif
 endif
 
@@ -66,10 +69,10 @@ PDCURSES_WIN_H	= $(osdir)/pdcwin.h
 
 CC	= $(PREFIX)gcc
 
-AR	= ar
-STRIP	= strip
+AR	= $(PREFIX)ar
+STRIP	= $(PREFIX)strip
 
-CFLAGS  = -Wall -Wextra -pedantic
+CFLAGS  += -Wall -Wextra -pedantic
 ifeq ($(DEBUG),Y)
 	CFLAGS  += -g -DPDCDEBUG
 	LDFLAGS = -g


### PR DESCRIPTION
WINCON/WINGUI Makefile improvements/fixes:
- Added _a64 setting for cross-compilation for Windows on Arm.
- Enabled custom CFLAGS by adding flags instead of clearing the CFLAGS variable.
- Fixed missing prefixes to complete the AR and STRIP commands to properly support cross-compiling.