### PR TITLE
Fix: a function declaration without a prototype is deprecated in all versions of C

### DIFF
--- a/demos/test_pan.c
+++ b/demos/test_pan.c
@@ -69,7 +69,7 @@ PANEL *panel_from_point( const int y, const int x)
    return( NULL);
 }
 
-int main()
+int main(void)
 {
    WINDOW *my_wins[3];
    PANEL  *my_panels[3];


### PR DESCRIPTION
Fixes error compiling using the more restrictive LLVM:
```bash
x86_64-w64-mingw32-gcc -Wall -Wextra -Werror -pedantic -fPIC -O2 -DPDC_WIDE -DPDC_FORCE_UTF8 -I..  -o test_pan.exe ../demos/test_pan.c libpdcurses.a -L/root/sdl2/SDL2-2.26.4/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2 -mwindows -L/root/sdl2/SDL2_ttf-2.20.2/x86_64-w64-mingw32/lib -lSDL2_ttf
../demos/test_pan.c:72:9: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
int main()
        ^
         void
1 error generated.
make: *** [Makefile:203: test_pan.exe] Error 1
```