### PR TITLE
Fix calling convention for Win32 DPI-related API calls.

### DIFF
--- a/wingui/pdcdisp.c
+++ b/wingui/pdcdisp.c
@@ -204,7 +204,7 @@ function address at runtime. if the method isn't available, that means we're on
 and older operating system, so we just return the original value */
 static LONG scale_font_for_current_dpi( LONG size)
 {
-    typedef LONG(__stdcall *GetDpiForSystemProc)();
+    typedef LONG(STDAPICALLTYPE *GetDpiForSystemProc)();
     HMODULE user32Dll = LoadLibrary( _T("User32.dll"));
 
     if ( user32Dll)

--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -2224,7 +2224,7 @@ int PDC_scr_open(void)
         wine_version = (wine_version_func)GetProcAddress(hntdll, "wine_get_version");
 
     if ( shcoredll) {
-        typedef HRESULT *(CDECL *set_process_dpi_awareness_t)(int);
+        typedef HRESULT(STDAPICALLTYPE *set_process_dpi_awareness_t)(int);
         static set_process_dpi_awareness_t set_process_dpi_awareness_func;
         static int ADJUST_DPI_PER_MONITOR = 2;
         set_process_dpi_awareness_func = (set_process_dpi_awareness_t)GetProcAddress(shcoredll, "SetProcessDpiAwareness");


### PR DESCRIPTION
Use `STDAPICALLTYPE` when dynamically resolving DPI-related API calls. 