### PR TITLE
[WIN32] external definition adjusted

### DIFF
--- a/curses.h
+++ b/curses.h
@@ -372,7 +372,7 @@ typedef struct _screen SCREEN;
 # ifdef CURSES_LIBRARY
 #  define PDCEX __declspec(dllexport) extern
 # else
-#  define PDCEX __declspec(dllimport)
+#  define PDCEX __declspec(dllimport) extern
 # endif
 #else
 # define PDCEX extern


### PR DESCRIPTION
always use modifier `extern`, not only the attribute `__declspec`

Note: this works "as-is" since >17 years, but I still think the attribute should not be used "alone"