### PR TITLE
Eliminated numpad key repeat issue for sdl2 and gl on Windows. Fixes …

### DIFF
--- a/gl/pdckbd.c
+++ b/gl/pdckbd.c
@@ -292,10 +292,8 @@ static int _process_key_event(void)
                 (key_table[i].numkeypad && (event.key.keysym.mod & KMOD_NUM)))
             {
                 key = key_table[i].shifted;
-#ifdef __linux
                 if( (key >= '0' && key <= '9') || strchr( ".+-*/", key))
                     key = -1;
-#endif
             }
             else if (event.key.keysym.mod & KMOD_CTRL)
             {

--- a/sdl2/pdckbd.c
+++ b/sdl2/pdckbd.c
@@ -292,10 +292,8 @@ static int _process_key_event(void)
                 (key_table[i].numkeypad && (event.key.keysym.mod & KMOD_NUM)))
             {
                 key = key_table[i].shifted;
-#ifdef __linux
                 if( (key >= '0' && key <= '9') || strchr( ".+-*/", key))
                     key = -1;
-#endif
             }
             else if (event.key.keysym.mod & KMOD_CTRL)
             {


### PR DESCRIPTION
…#304

I must admit that I don't know why the ifdefs were in place to begin with, nor do I understand the implications of changing this for other platforms besides Windows 11. However, I do know that this change fixes the issue for me on Windows 11