### PR TITLE
pdc_window_title to set the SDL window title

### DIFF
--- a/gl/pdcgl.h
+++ b/gl/pdcgl.h
@@ -32,6 +32,7 @@ PDCEX  int pdc_interpolation_mode; /* PDC_GL_INTERPOLATE_BILINEAR by default */
 PDCEX  SDL_Window *pdc_window;
 PDCEX  SDL_Surface *pdc_icon;
 PDCEX  int pdc_sheight, pdc_swidth;
+PDCEX  const char *pdc_window_title;
 
 extern Uint32 *pdc_glyph_cache[4];
 extern int pdc_glyph_cache_size[4];

--- a/gl/pdcscrn.c
+++ b/gl/pdcscrn.c
@@ -29,6 +29,7 @@ int pdc_font_size =
 #endif
 int pdc_resize_mode = PDC_GL_RESIZE_NORMAL;
 int pdc_interpolation_mode = PDC_GL_INTERPOLATE_BILINEAR;
+const char *pdc_window_title = NULL;
 
 Uint32 *pdc_glyph_cache[4] = {NULL, NULL, NULL, NULL};
 int pdc_glyph_cache_size[4] = {0, 0, 0, 0};
@@ -405,7 +406,7 @@ int PDC_scr_open(void)
     SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 0);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 0);
 
-    pdc_window = SDL_CreateWindow("PDCurses",
+    pdc_window = SDL_CreateWindow(pdc_window_title ? pdc_window_title : "PDCurses",
         SDL_WINDOWPOS_CENTERED_DISPLAY(displaynum),
         SDL_WINDOWPOS_CENTERED_DISPLAY(displaynum),
         pdc_swidth, pdc_sheight,

--- a/sdl2/pdcscrn.c
+++ b/sdl2/pdcscrn.c
@@ -36,6 +36,7 @@ SDL_Window *pdc_window = NULL;
 SDL_Surface *pdc_screen = NULL, *pdc_font = NULL, *pdc_icon = NULL,
             *pdc_back = NULL, *pdc_tileback = NULL;
 int pdc_sheight = 0, pdc_swidth = 0, pdc_yoffset = 0, pdc_xoffset = 0;
+const char *pdc_window_title = NULL;
 
 int pdc_fheight, pdc_fwidth, pdc_fthick, pdc_flastc;
 bool pdc_own_window;
@@ -357,7 +358,7 @@ int PDC_scr_open(void)
         }
         pdc_swidth *= pdc_fwidth;
 
-        pdc_window = SDL_CreateWindow("PDCurses",
+        pdc_window = SDL_CreateWindow(pdc_window_title ? pdc_window_title : "PDCurses",
             SDL_WINDOWPOS_CENTERED_DISPLAY(displaynum),
             SDL_WINDOWPOS_CENTERED_DISPLAY(displaynum),
             pdc_swidth, pdc_sheight, SDL_WINDOW_RESIZABLE);

--- a/sdl2/pdcsdl.h
+++ b/sdl2/pdcsdl.h
@@ -28,6 +28,7 @@ PDCEX int pdc_sdl_render_mode;
 PDCEX  SDL_Window *pdc_window;
 PDCEX  SDL_Surface *pdc_screen, *pdc_font, *pdc_icon, *pdc_back;
 PDCEX  int pdc_sheight, pdc_swidth, pdc_yoffset, pdc_xoffset;
+PDCEX  const char *pdc_window_title;
 
 extern SDL_Surface *pdc_tileback;    /* used to regenerate the background
                                         of "transparent" cells */


### PR DESCRIPTION
It seems like there is no reason not to allow users of PDCursesMod to set the window title. This commit would allow this in SDL2 and GL builds, via the variable `const char *pdc_window_title`. I also had the thought that the default window title should be "PDCursesMod" rather than "PDCurses", but decided not to change it, as that is only tangentially related to the feature I am adding.