### PR TITLE
Fixed issue where mouse clicks were always reported as separate button down and button up events.

### DIFF
--- a/gl/pdckbd.c
+++ b/gl/pdckbd.c
@@ -415,9 +415,7 @@ static int _process_mouse_event(void)
         {
             SDL_Event rel;
 
-            napms(SP->mouse_wait);
-
-            if (SDL_PollEvent(&rel))
+            if (SDL_WaitEventTimeout(&rel, SP->mouse_wait))
             {
                 if (rel.type == SDL_MOUSEBUTTONUP && rel.button.button == btn)
                     action = BUTTON_CLICKED;

--- a/sdl2/pdckbd.c
+++ b/sdl2/pdckbd.c
@@ -408,9 +408,7 @@ static int _process_mouse_event(void)
         {
             SDL_Event rel;
 
-            napms(SP->mouse_wait);
-
-            if (SDL_PollEvent(&rel))
+            if (SDL_WaitEventTimeout(&rel, SP->mouse_wait))
             {
                 if (rel.type == SDL_MOUSEBUTTONUP && rel.button.button == btn)
                     action = BUTTON_CLICKED;


### PR DESCRIPTION
SDL_PollEvent was always returning 0, which meant we never set `action = BUTTON_CLICKED`. Using SDL_WaitEventTimeout instead of napms followed by SDL_PollEvent seems to fix this.
I mentioned this bug in issue #117.