### PR TITLE
Added double and triple click detection for SDL2 and GL

### DIFF
--- a/gl/pdckbd.c
+++ b/gl/pdckbd.c
@@ -415,12 +415,22 @@ static int _process_mouse_event(void)
         {
             SDL_Event rel;
 
-            if (SDL_WaitEventTimeout(&rel, SP->mouse_wait))
+            while (action != BUTTON_TRIPLE_CLICKED && SDL_WaitEventTimeout(&rel, SP->mouse_wait))
             {
                 if (rel.type == SDL_MOUSEBUTTONUP && rel.button.button == btn)
-                    action = BUTTON_CLICKED;
-                else
+                {
+                    if (action == BUTTON_PRESSED)
+                        action = BUTTON_CLICKED;
+                    else if (action == BUTTON_CLICKED)
+                        action = BUTTON_DOUBLE_CLICKED;
+                    else if (action == BUTTON_DOUBLE_CLICKED)
+                        action = BUTTON_TRIPLE_CLICKED;
+                }
+                else if(rel.type != SDL_MOUSEBUTTONDOWN || rel.button.button != btn)
+                {
                     SDL_PushEvent(&rel);
+                    break;
+                }
             }
         }
 

--- a/sdl2/pdckbd.c
+++ b/sdl2/pdckbd.c
@@ -408,12 +408,22 @@ static int _process_mouse_event(void)
         {
             SDL_Event rel;
 
-            if (SDL_WaitEventTimeout(&rel, SP->mouse_wait))
+            while (action != BUTTON_TRIPLE_CLICKED && SDL_WaitEventTimeout(&rel, SP->mouse_wait))
             {
                 if (rel.type == SDL_MOUSEBUTTONUP && rel.button.button == btn)
-                    action = BUTTON_CLICKED;
-                else
+                {
+                    if (action == BUTTON_PRESSED)
+                        action = BUTTON_CLICKED;
+                    else if (action == BUTTON_CLICKED)
+                        action = BUTTON_DOUBLE_CLICKED;
+                    else if (action == BUTTON_DOUBLE_CLICKED)
+                        action = BUTTON_TRIPLE_CLICKED;
+                }
+                else if(rel.type != SDL_MOUSEBUTTONDOWN || rel.button.button != btn)
+                {
                     SDL_PushEvent(&rel);
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
SDL2 and GL builds were not detecting double or triple clicks, but instead would just produce a series of single click events when clicking multiple times. This simply turns the click detection into a loop that increments from BUTTON_PRESSED to BUTTON_CLICKED to BUTTON_DOUBLE_CLICKED to BUTTON_TRIPLE_CLICKED and bails out if any other input is received.

I get the impression from #117 that you wanted to refine the logic for double and triple click detection used in wingui and then port it over to other platforms, but maybe we can use this for sdl2 and gl until then.