### PR TITLE
Clear clipboard requires clipboard to be opened

### DIFF
--- a/common/winclip.c
+++ b/common/winclip.c
@@ -140,7 +140,12 @@ int PDC_clearclipboard(void)
 {
     PDC_LOG(("PDC_clearclipboard() - called\n"));
 
+    if (!OpenClipboard(NULL))
+        return PDC_CLIP_ACCESS_ERROR;
+
     EmptyClipboard();
+
+    CloseClipboard();
 
     return PDC_CLIP_SUCCESS;
 }


### PR DESCRIPTION
As with other clipboard command, the clipboard needs to be open for them to work.