### PR TITLE
WinCon: define all of PDC_WIDE, UNICODE, _UNICODE if one of those are defined

### DIFF
--- a/wincon/pdcwin.h
+++ b/wincon/pdcwin.h
@@ -12,8 +12,16 @@
    #define PDC_WIDE
 #endif
 
-#if defined(PDC_WIDE) && !defined(UNICODE)
-# define UNICODE
+#if defined( PDC_WIDE) || defined( UNICODE) || defined( _UNICODE)
+   #if !defined( PDC_WIDE)
+      # define PDC_WIDE
+   #endif
+   #if !defined( UNICODE)
+      # define UNICODE
+   #endif
+   #if !defined( _UNICODE)
+      # define _UNICODE
+   #endif
 #endif
 
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Per MSDN one should always define both macros, as they are used in different contexts, but must match. The definition of `UNICODE` can also be provided by the build environment, especially with MSVC, in which case PDC_WIDE must be defined as well.

In general - shouldn't we move that to another (common internal) header, wrapping it in `#ifdef _WIN32`?

Apart from wincon we have that also in wingui, vt and (not sure it is needed/useful there) fb:

https://github.com/Bill-Gray/PDCursesMod/blob/d2f479a8301e0b9b6278a98524efaaaa5e3a1877/wingui/pdcwin.h#L13-L20
https://github.com/Bill-Gray/PDCursesMod/blob/d2f479a8301e0b9b6278a98524efaaaa5e3a1877/vt/pdcvt.h#L9-L16
https://github.com/Bill-Gray/PDCursesMod/blob/d2f479a8301e0b9b6278a98524efaaaa5e3a1877/fb/pdcfb.h#L1-L8