### PR TITLE
WinCon/pdcscrn.c: support stdio redirections

### DIFF
--- a/wincon/pdcscrn.c
+++ b/wincon/pdcscrn.c
@@ -402,12 +402,15 @@ int PDC_scr_open(void)
     _reset_old_colors();
 
     std_con_out =
-    pdc_con_out = GetStdHandle(STD_OUTPUT_HANDLE);
-    pdc_con_in = GetStdHandle(STD_INPUT_HANDLE);
+    pdc_con_out = CreateFile(TEXT("CONOUT$"), GENERIC_READ | GENERIC_WRITE,
+                             FILE_SHARE_WRITE, NULL, OPEN_EXISTING, 0, NULL);
+    pdc_con_in = CreateFile(TEXT("CONIN$"), GENERIC_READ | GENERIC_WRITE,
+                            FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
 
-    if (GetFileType(pdc_con_in) != FILE_TYPE_CHAR)
+    if (pdc_con_out == INVALID_HANDLE_VALUE ||
+        pdc_con_in == INVALID_HANDLE_VALUE)
     {
-        fprintf(stderr, "\nRedirection is not supported.\n");
+        fprintf(stderr, "\nCannot open console.\n");
         exit(1);
     }
 


### PR DESCRIPTION
* Instead of querying STD_INPUT_HANDLE/STD_OUTPUT_HANDLE to get the console handle, always open CONIN$ and CONOUT$, which works even after redirecting stdin/stdout. See also https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea#consoles
* This fixes e.g. SciTECO's --stdin/--stdout when used in combination with its interactive mode.
* It's an open question whether this approach is supported by ancient Windows versions as well.
* While this will fix applications that work with stdin/stdout besides or before using the Curses API, you will not of course capture any escape sequences when redirecting stdout as asked for in #50.
* Of course we might say that you have to pass in console handles via newterm(), as you would do on ncurses, but the API is expecting FILE* instead. As long as you cannot effectively pass in your own console handles, this patch shouldn't make anything worse. See also #256.