### PR TITLE
Fixed apparent typo preventing mouse wheel working with wincon

### DIFF
--- a/wincon/pdckbd.c
+++ b/wincon/pdckbd.c
@@ -617,13 +617,13 @@ static void _process_mouse_event(void)
 
     /* Handle scroll wheel */
 
-#ifdef HOUSE_WHEELED
+#ifdef MOUSE_WHEELED
     if (MEV.dwEventFlags == MOUSE_WHEELED)
         event = (MEV.dwButtonState & 0xFF000000) ?
                PDC_MOUSE_WHEEL_DOWN : PDC_MOUSE_WHEEL_UP;
 #endif
 
-#ifdef HOUSE_HWHEELED
+#ifdef MOUSE_HWHEELED
     if (MEV.dwEventFlags == MOUSE_HWHEELED)
         event = (MEV.dwButtonState & 0xFF000000) ?
                PDC_MOUSE_WHEEL_RIGHT : PDC_MOUSE_WHEEL_LEFT;


### PR DESCRIPTION
I noticed that the mouse wheel wasn't working at all in the windows console build. It seems that a change was added to check for mouse wheel support, but it looks like a typo to me.

This PR corrects the typo and restores mouse wheel functionality.