### PR TITLE
fix warning on wingui/pdcscrn.c MSYS2 ARM64

### DIFF
--- a/wingui/pdcscrn.c
+++ b/wingui/pdcscrn.c
@@ -1613,9 +1613,12 @@ Note,  though,  that in Win9x,  detection of the Shift keys is hardware
 dependent;  if you've an unusual keyboard,  both Shift keys may be
 detected as right, or both as left. */
 
-#if defined(_WIN32) && defined(__GNUC__) && !defined(_ARM64_)
+#if defined(__has_attribute)
+#if __has_attribute(force_align_arg_pointer)
 #define ALIGN_STACK __attribute__((force_align_arg_pointer))
-#else
+#endif
+#endif
+#if !defined(ALIGN_STACK)
 #define ALIGN_STACK
 #endif
 


### PR DESCRIPTION
compiling on MSYS2 Windows 11 ARM64

clang version 21.1.5
Target: aarch64-w64-windows-gnu
Thread model: posix
InstalledDir: C:/msys64/clangarm64/bin

../wingui/pdcscrn.c:1622:16: warning: unknown attribute 'force_align_arg_pointer' ignored
      [-Wunknown-attributes]
 1622 | static LRESULT ALIGN_STACK CALLBACK WndProc (const HWND hwnd,
      |                ^~~~~~~~~~~
../wingui/pdcscrn.c:1617:36: note: expanded from macro 'ALIGN_STACK'
 1617 | #define ALIGN_STACK __attribute__((force_align_arg_pointer))
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.