### PR TITLE
chore: optimize cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,8 @@ else()
    
 endif()
 
+install(FILES curses.h panel.h DESTINATION ${CMAKE_BUILD_TYPE}/include)
+
 add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/make_uninstall.cmake")
 
 set(CPACK_COMPONENTS_ALL applications)

--- a/cmake/project_common.cmake
+++ b/cmake/project_common.cmake
@@ -84,6 +84,11 @@ if(PDC_BUILD_SHARED)
         set_target_properties(${PDCURSE_PROJ} PROPERTIES MACOSX_RPATH 1)
     endif()
 
+    if(APPLE OR UNIX)
+        target_compile_definitions(${PDCURSE_PROJ} PRIVATE PDC_ENABLE_VISIBILITY)
+        set_target_properties(${PDCURSE_PROJ} PROPERTIES C_VISIBILITY_PRESET hidden)
+    endif()
+
     if(${PROJECT_NAME} STREQUAL "sdl2")
         if(PDC_WIDE OR PDC_UTF8)
             target_link_libraries(${PDCURSE_PROJ} ${EXTRA_LIBS}

--- a/cmake/project_common.cmake
+++ b/cmake/project_common.cmake
@@ -130,5 +130,11 @@ macro (demo_app dir targ)
     add_dependencies(${bin_name} ${PDCURSE_PROJ})
     set_target_properties(${bin_name} PROPERTIES OUTPUT_NAME ${targ})
 
+    if(APPLE)
+        set_target_properties(${bin_name} PROPERTIES INSTALL_RPATH "@executable_path/../../lib/${PROJECT_NAME}")
+    elseif(UNIX)
+        set_target_properties(${bin_name} PROPERTIES INSTALL_RPATH "$ORIGIN/../../lib/${PROJECT_NAME}")
+    endif()
+
     install(TARGETS ${bin_name} RUNTIME DESTINATION ${PDCURSES_DIST}/bin/${PROJECT_NAME} COMPONENT applications)
 endmacro ()

--- a/curses.h
+++ b/curses.h
@@ -398,7 +398,11 @@ typedef struct _screen SCREEN;
 #  define PDCEX __declspec(dllimport) extern
 # endif
 #else
-# define PDCEX extern
+# ifdef PDC_ENABLE_VISIBILITY
+#  define PDCEX __attribute__((visibility("default"))) extern
+# else
+#  define PDCEX extern
+# endif
 #endif
 
 PDCEX  int          LINES;        /* terminal height */


### PR DESCRIPTION
* Install headers to `${CMAKE_BUILD_TYPE}/include`.

* Set `CMAKE_INSTALL_RPATH` for demos on macos and linux. Previously the installed demos cannot be executed.

* Set `CMAKE_C_VISIBILITY_PRESET` to `hidden` on macos and linux, which prevent about 60 symbols being exported.
