### PR TITLE
vt pdckbd (PDC_get_key): fix missing init warnings

### DIFF
--- a/vt/pdckbd.c
+++ b/vt/pdckbd.c
@@ -307,16 +307,15 @@ int PDC_get_key( void)
       }
    if( check_key( &rval))
       {
-      int c[MAX_COUNT], modifiers = 0;
+      int c[MAX_COUNT] = { 0 }, modifiers = 0;
 
 #ifdef USE_CONIO
       if( rval == 0 || rval == 224)
          {
-         int key2;
-
-#ifdef __DJGPP__                 /* DJGPP returns kbhit() = 1 only once for */
-         key2 = dmc_getch( );    /* escape sequences,  not twice as other  */
-#else                            /* compilers for MS-DOS do */
+#ifdef __DJGPP__                   /* DJGPP returns kbhit() = 1 only once for */
+         int key2 = dmc_getch( );  /* escape sequences,  not twice as other  */
+#else                              /* compilers for MS-DOS do */
+         int key2 = 0;
          while( !check_key( &key2))
             ;
 #endif


### PR DESCRIPTION
fixes #373 
some of the variables are passed as pointers to sub-functions but may not always be set - explicit initialize to fix the init-warning this results in