### PR TITLE
Fix PSF1 magic-number check in common/psf.c (uses && instead of ||)

### DIFF
--- a/common/psf.c
+++ b/common/psf.c
@@ -46,7 +46,7 @@ static int _load_psf1( struct font_info *f, const uint8_t *buff, const long file
    struct psf1_header hdr;
    int n_references_found = 0;
 
-   if( buff[0] != PSF1_MAGIC0 && buff[1] != PSF1_MAGIC1)
+   if( buff[0] != PSF1_MAGIC0 || buff[1] != PSF1_MAGIC1)
       return( -1);
    memcpy( &hdr, buff, sizeof( hdr));
    f->font_type = 1;


### PR DESCRIPTION
\`_load_psf1()\` in \`common/psf.c\` rejects a candidate PSF1 font buffer only when **both** magic bytes fail to match:

\`\`\`c
if( buff[0] != PSF1_MAGIC0 && buff[1] != PSF1_MAGIC1)
   return( -1);
\`\`\`

This means a buffer that matches only one of the two magic bytes (e.g. \`buff[0] == PSF1_MAGIC0\` but \`buff[1] != PSF1_MAGIC1\`) is wrongly accepted as a valid PSF1 font. Compare with the sibling check in \`_load_psf2()\` a few lines below, which correctly uses \`||\` across all four magic bytes:

\`\`\`c
if( buff[0] != PSF2_MAGIC0 || buff[1] != PSF2_MAGIC1
         || buff[2] != PSF2_MAGIC2 || buff[3] != PSF2_MAGIC3)
   return( -1);
\`\`\`

This PR changes the PSF1 check to use \`||\` to match that pattern, so any mismatching magic byte correctly rejects the buffer.

**Why it matters:** a malformed/non-PSF1 file (e.g. loaded via the \`PDC_FONT\`/\`PDC_FONT2\`..\`PDC_FONT9\` env vars in \`fb/pdcscrn.c\`) can slip past validation with garbage header fields (\`n_glyphs\`, \`charsize\`), which are then used downstream to size a \`memcpy\` of glyph data.

Tested by compiling \`_load_psf1()\` from the actual repo source (unmodified) against a crafted buffer where \`buff[0] == PSF1_MAGIC0\` but \`buff[1] != PSF1_MAGIC1\`:
- Before the fix: returns \`0\` (incorrectly accepted).
- After the fix: returns \`-1\` (correctly rejected).