### PR TITLE
Fix heap buffer underflow in PDC_mbstowcs()

### DIFF
--- a/pdcurses/util.c
+++ b/pdcurses/util.c
@@ -465,6 +465,8 @@ size_t PDC_mbstowcs(wchar_t *dest, const char *src, size_t n)
     }
 # else
     size_t i = mbstowcs(dest, src, n);
+    if (i == (size_t)-1)        /* an invalid multibyte sequence */
+        return i;
 # endif
     dest[i] = 0;
     return i;
@@ -473,28 +475,32 @@ size_t PDC_mbstowcs(wchar_t *dest, const char *src, size_t n)
 size_t PDC_wcstombs(char *dest, const wchar_t *src, size_t n)
 {
 # ifdef PDC_FORCE_UTF8
-    size_t i = 0;
+    size_t i = 0, count = 1;
 
     assert( src);
     assert( dest);
     if (!src || !dest)
         return 0;
 
-    while( i + 4 < n && *src)
-       i += PDC_wc_to_utf8( dest + i, *src++);
-    while( i < n && *src)
+    while( count && i + 4 < n && *src)
+       i += (count = PDC_wc_to_utf8( dest + i, *src++));
+    while( count && i < n && *src)
     {
        char tbuff[4];
-       size_t count = (size_t)PDC_wc_to_utf8( tbuff, *src++);
 
-       assert( count <= n - i);  /* partial UTF-8 decoding indicates error */
+       count = (size_t)PDC_wc_to_utf8( tbuff, *src++);
+       assert( count <= n - i);    /* don't go past end of buffer */
        if( count > n - i)
            count = n - i;
        memcpy( dest + i, tbuff, count);
        i += count;
     }
+    if( !count)                 /* invalid UTF-8 sequence encountered */
+        return (size_t)-1;
 # else
     size_t i = wcstombs(dest, src, n);
+    if( i == (size_t)-1)        /* a character the locale cannot encode */
+        return i;
 # endif
     dest[i] = '\0';
     return i;


### PR DESCRIPTION
Fixes #383.

`mbstowcs()` returns `(size_t)-1` on an invalid multibyte sequence, without writing a terminator, and `PDC_mbstowcs()` then stored the terminator at `dest[(size_t)-1]`, one element before the buffer. Return `(size_t)-1` with an empty `dest` instead, as `PDC_wcstombs()` does since ea9baa42.

With the `vt` port and a guard element placed before the buffer, `PDC_mbstowcs(buf, "AB\xff", 8)` in a UTF-8 locale overwrote the guard with 0 and left `buf` unterminated; it now leaves the guard alone and sets `buf[0] = 0`.

The `PDC_wcstombs()` half of the original PR is superseded by ea9baa42 (see #390 / #391 for the exact-fit case).